### PR TITLE
Use a --size of 'off' to get no clustering

### DIFF
--- a/test/supervisor.js
+++ b/test/supervisor.js
@@ -96,7 +96,7 @@ describe('supervisor', function(done) {
       /argv:.*index.js.*size=10/
     ];
 
-    run('.', ['--size', '0', 'test/module-app/index.js', '--size=10'], EXPECT);
+    run('.', ['--size', 'off', 'test/module-app/index.js', '--size=10'], EXPECT);
     run('.', ['--size', '1', 'test/module-app/index.js', '--size=10'], EXPECT);
 
     run('.', ['--help', 'help-option'], [/usage: slr/]);


### PR DESCRIPTION
A size of 0 no longer triggers no-clustering, use a size of off.
