### PR TITLE
Re-require strong-cluster-control so agent sees it

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -109,6 +109,10 @@ config.start = function start() {
     }
   }
 
+  // Re-require this so that strong-agent (which may be required by now)
+  // notices, and attaches cluster control instrumentation.
+  require('strong-cluster-control');
+
   control.on('start', function(addr) {
     console.error('supervisor listening on \'%s\'', addr);
   });


### PR DESCRIPTION
strong-supervisor plays a bit fast and loose with strong-agent, in that
it doesn't require it before strong-cluster-control (because until its
looked at the strong-cluster-control options, it can't evaluate its
command line, and doesn't know if it has to require strong-agent). This
apparently side-effect less require of strong-cluster-control allows the
agent probes to see it is in use, and to enable the cluster control
panel.
