### PR TITLE
Remove listener limit on supervisor's log stream

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -138,6 +138,11 @@ config.start = function start() {
     supervisorLog = new LogWriter(process, options);
   }
 
+  // In the recommended mode where worker logs are piped through the
+  // supervisor's stdout, each worker adds 6 lisenters (3 per output stream)
+  // for piping alone. The default is 10.
+  supervisorLog.setMaxListeners(0);
+
   logger.sink = transformer({ tag: { pid: process.pid, worker: 'supervisor' },
                               timeStamp: true, destination: supervisorLog });
 


### PR DESCRIPTION
Each worker adds 6 listeners to the supervisor's LogWriter when their
logs are fed through the supervisor's stdout. When the maximum number
of listeners (default 10) is exceeded warnings are printed to the
console.

@sam-github PTAL.
