### PR TITLE
Configurable log timestamping

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -144,7 +144,8 @@ config.start = function start() {
   supervisorLog.setMaxListeners(0);
 
   logger.sink = transformer({ tag: { pid: process.pid, worker: 'supervisor' },
-                              timeStamp: true, destination: supervisorLog });
+                              timeStamp: options.timeStampSupervisorLogs,
+                              destination: supervisorLog });
 
   cluster.on('fork', function(worker) {
     var tag = { pid: worker.process.pid, worker: worker.id };

--- a/lib/options.js
+++ b/lib/options.js
@@ -33,6 +33,8 @@ exports.HELP = [
   '                     FILE defaults to "-", which implied stdout.',
   '  --no-timestamp-workers',
   '                     Disable timestamping of worker log lines by supervisor',
+  '  --no-timestamp-supervisor',
+  '                     Disable timestamping of supervisor log messages',
   '  -p,--pid FILE      Write supervisor\'s pid to FILE, failing if FILE',
   '                     already has a valid pid in it (default is not to)',
   '  --cluster N        Set the cluster size (default is off, but see below).',
@@ -59,6 +61,7 @@ exports.parse = function parse(argv) {
     profile: true,
     log: false,
     timeStampWorkerLogs: true,
+    timeStampSupervisorLogs: true,
   };
   for(var i = 2; i < argv.length; i++) {
     var option = argv[i];
@@ -124,6 +127,9 @@ exports.parse = function parse(argv) {
     }
     else if (option === '--no-timestamp-workers') {
       options.timeStampWorkerLogs = false;
+    }
+    else if (option === '--no-timestamp-supervisor') {
+      options.timeStampSupervisorLogs = false;
     }
     else {
       options.argv = argv.slice(0,i);

--- a/test/supervisor.js
+++ b/test/supervisor.js
@@ -113,6 +113,7 @@ describe('supervisor', function(done) {
     var TS_WORKER = /^\d+-\d+-\d+T\d+:\d+:\d+.\d+Z pid:\d+ worker:\d+ .+/;
     var TS_SUPER = /^\d+-\d+-\d+T\d+:\d+:\d+.\d+Z pid:\d+ worker:supervisor .+/;
     var NO_TS_WORKER = /^pid:\d+ worker:\d+ .+/;
+    var NO_TS_SUPER = /^pid:\d+ worker:supervisor .+/;
 
     describe('worker logs', function() {
       var EXPECT_TIMESTAMPS = [ TS_WORKER, TS_SUPER ];
@@ -120,6 +121,14 @@ describe('supervisor', function(done) {
 
       run('.', ['--cluster', '1', 'test/yes-app'], EXPECT_TIMESTAMPS);
       run('.', ['--cluster', '1', '--no-timestamp-workers', 'test/yes-app'], EXPECT_NO_TIMESTAMPS);
+    });
+
+    describe('supervisor logs', function() {
+      var EXPECT_TIMESTAMPS = [ TS_WORKER, TS_SUPER ];
+      var EXPECT_NO_TIMESTAMPS = [ TS_WORKER, NO_TS_SUPER ];
+
+      run('.', ['--cluster', '1', 'test/yes-app'], EXPECT_TIMESTAMPS);
+      run('.', ['--cluster', '1', '--no-timestamp-supervisor', 'test/yes-app'], EXPECT_NO_TIMESTAMPS);
     });
   });
 });


### PR DESCRIPTION
First pass has them as separate options, `--no-timestamp-workers` and `--no-timestamp-supervisor`.

They are separate because the supervisor's log messages are not timestamped, but the worker logs may be timestamped in-app. The only way to make them "equally" timestamped is to have the controls independent.

R= @sam-github @kraman 
