### PR TITLE
more pipes, less mistakes

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -144,22 +144,23 @@ config.start = function start() {
   supervisorLog.setMaxListeners(0);
 
   logger.sink = transformer({ tag: { pid: process.pid, worker: 'supervisor' },
-                              timeStamp: true, destination: supervisorLog });
+                              timeStamp: true });
+  logger.sink.pipe(supervisorLog);
 
   cluster.on('fork', function(worker) {
     var tag = { pid: worker.process.pid, worker: worker.id };
     var logStream = isPerWorker
                   ? new LogWriter(worker, options)  // cleaned up by pipe()
                   : supervisorLog;                  // cleaned up by exit()
-    var outLog = transformer({ timeStamp: true, tag: tag, destination: logStream });
-    var errLog = transformer({ timeStamp: true, tag: tag, destination: logStream, mergeLines: true });
+    var outLog = transformer({ timeStamp: true, tag: tag });
+    var errLog = transformer({ timeStamp: true, tag: tag, mergeLines: true });
     // When we have per-worker logs, each worker gets their own LogWriter, which
     // gets cleaned up when the stream piped into it emits 'end'.
     // When we don't have per-worker logs, we need to suppress the propagation
     // of 'end' from the pipe so we don't close the supervisor's log the first
     // time a worker exits.
-    worker.process.stdout.pipe(outLog, {end: isPerWorker});
-    worker.process.stderr.pipe(errLog, {end: isPerWorker});
+    worker.process.stdout.pipe(outLog).pipe(logStream, {end: isPerWorker});
+    worker.process.stderr.pipe(errLog).pipe(logStream, {end: isPerWorker});
     worker.logFile = logStream;
   });
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "strong-agent": "~0.4.0",
     "strong-cluster-control": "~0.4.0",
-    "strong-log-transformer": "~0.0.1"
+    "strong-log-transformer": "~0.1.0"
   },
   "peerDependencies": {
     "strong-cluster-control": "~0.4.0"


### PR DESCRIPTION
Upgrade strong-log-transformer to a more pipe-able version. Using
the .pipe() interface is less error prone than mimicing .pipe().
