### PR TITLE
Log command piping

### DIFF
--- a/lib/log-writer.js
+++ b/lib/log-writer.js
@@ -1,6 +1,7 @@
 var util = require('util');
 var stream = require('stream');
 var fs = require('fs');
+var spawn = require('child_process').spawn;
 
 var generateLogName = require('./logname').generate;
 
@@ -17,7 +18,17 @@ function LogWriter(worker, options) {
     pid: worker.pid || worker.process.pid
   }
   this.name = generateLogName(this.template, this.worker);
-  this.sink = fs.createWriteStream(this.name, { flags: 'a'});
+  if (/^\|[^\|]/.test(this.name)) {
+    this.cmd = this.name
+                .slice(1) // strip leading '|'
+                .trim()
+                .split(/\s+/);
+    this.proc = spawn(this.cmd[0], this.cmd.slice(1),
+                      { stdio: ['pipe', process.stdout, process.stderr] });
+    this.sink = this.proc.stdin;
+  } else {
+    this.sink = fs.createWriteStream(this.name, { flags: 'a'});
+  }
   this.pipe(this.sink);
 }
 


### PR DESCRIPTION
Add's `| cmd` support to the `--log` option, allowing for `sl-run --cluster 4 --log '| logger -t "pid:%p worker:%w"'` which will create a `logger` child process for the supervisor and each worker, piping each process's stdin.

Resolves SLN-929
