### PR TITLE
runctl: rename object tracking commands

### DIFF
--- a/bin/sl-runctl.js
+++ b/bin/sl-runctl.js
@@ -61,8 +61,8 @@ function cli(argv, version, cb) {
   }
 
   program
-  .command('set-size')
-  .description('set-size N, set cluster size to N workers')
+  .command('set-size <N>')
+  .description('set cluster size to N workers')
   .action(function(size) {
     request.cmd = 'set-size';
     request.size = parseInt(size, 10);
@@ -86,8 +86,8 @@ function cli(argv, version, cb) {
   });
 
   program
-  .command('start-tracking-objects')
-  .description('start-tracking-objects TARGET, on a worker ID or process PID')
+  .command('objects-start <T>')
+  .description('start tracking objects on T, a worker ID or process PID')
   .action(function(target) {
     request.cmd = 'start-tracking-objects';
     request.target = target;
@@ -95,8 +95,8 @@ function cli(argv, version, cb) {
   });
 
   program
-  .command('stop-tracking-objects')
-  .description('stop-tracking-objects TARGET, on a worker ID or process PID')
+  .command('objects-stop <T>')
+  .description('stop tracking objects on T, a worker ID or process PID')
   .action(function(target) {
     request.cmd = 'stop-tracking-objects';
     request.target = target;

--- a/test/test-runctl-object-tracking.js
+++ b/test/test-runctl-object-tracking.js
@@ -32,18 +32,21 @@ helper.statsd(function(statsd) {
   waiton('status', /worker count: 1/);
   expect('status', /worker id 1:/);
 
-  expect('start-tracking-objects 0');
-  expect('start-tracking-objects 1');
-  failon('start-tracking-objects 6', /6 not found/);
+  failon('objects-start', /missing required argument/);
+  failon('objects-stop', /missing required argument/);
+
+  expect('objects-start 0');
+  expect('objects-start 1');
+  failon('objects-start 6', /6 not found/);
 
   console.log('Waiting for stats...');
 
   statsd.waitfor(/object.*count:/, function() {
     statsd.close();
 
-    expect('stop-tracking-objects 0');
-    expect('stop-tracking-objects 1');
-    failon('stop-tracking-objects 6', /6 not found/);
+    expect('objects-stop 0');
+    expect('objects-stop 1');
+    failon('objects-stop 6', /6 not found/);
 
     expect('stop');
 


### PR DESCRIPTION
start-tracking-objects was too long, user feedback was to go shorter
with objects-start. Also, added tests for a missing argument.

/to @kraman 
