### PR TITLE
Allow master logging in --metrics mode

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -27,7 +27,7 @@ function sendMetrics() {
   }
 
   scope = expandString(scope, {
-    id: cluster.worker.id || 0,
+    id: (cluster.worker && cluster.worker.id) |0,
     pid: process.pid,
     hostname: agent.config.hostname,
     appName: agent.config.appName,


### PR DESCRIPTION
cluster.worker is null in the master, not empty.

Introduced in 1c92540324e34774209d926e977f40c1488a6790.

/cc @sam-github 
