### PR TITLE
runctl: clarify fork response and usage

### DIFF
--- a/bin/sl-runctl.js
+++ b/bin/sl-runctl.js
@@ -95,7 +95,7 @@ function cli(argv, version, cb) {
 
   program
   .command('fork')
-  .description('fork one worker')
+  .description('fork one worker (it will be killed if size is exceeded)')
   .action(function() {
     request.cmd = 'fork';
     display = console.log;

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -72,6 +72,9 @@ function onRequest(req, callback) {
 
   } else if(cmd === 'fork') {
     cluster.fork();
+    var child = cluster.fork();
+    rsp.workerID = child.workerID;
+    rsp.processID = child.process.pid;
 
   } else {
     // Pass any others off to the target

--- a/test/helper.js
+++ b/test/helper.js
@@ -135,7 +135,7 @@ function failon(cmd, output) {
   assert.notEqual(out.code, 0);
 
   if (output) {
-    assert(output.test(out.output), output);
+    assert(output.test(out.output), out.output);
   }
 }
 


### PR DESCRIPTION
https://github.com/strongloop/strong-cluster-control/pull/39  got lost during refactor of control channel from strong-cluster-control to strong-supervisor, this is the same diff, but applied to new repo.
