### PR TITLE
runctl: don't attach runctl server in workers

### DIFF
--- a/lib/runctl.js
+++ b/lib/runctl.js
@@ -1,6 +1,6 @@
 // run-time control channel
 var cluster = require('cluster');
-var debug = require('./debug')('channel');
+var debug = require('./debug')('runctl');
 var fs = require('fs');
 var master = require('strong-cluster-control');
 var targetctl = require('./targetctl');
@@ -9,9 +9,15 @@ var util = require('util');
 exports.start = start;
 exports.onRequest = onRequest; // For testing
 
-// Expose runctl using local domain server, and node IPC.
+// Expose runctl using local domain server
 var server = require('strong-control-channel/server').create(onRequest);
-var ipcctl = require('strong-control-channel/process').attach(onRequest);
+
+// Expose runctl using node IPC only in the master/supervisor (workers
+// attach targetctl to the master).
+
+if (cluster.isMaster) {
+  var ipcctl = require('strong-control-channel/process').attach(onRequest);
+}
 
 function start(options) {
   var logger = options.logger;
@@ -41,7 +47,7 @@ function start(options) {
 };
 
 function onRequest(req, callback) {
-  debug('request', req);
+  debug('request %s', debug.json(req));
 
   var cmd = req.cmd;
   var rsp = {


### PR DESCRIPTION
Workers have their node IPC channel attached to the supervisor/cluster
master, and only the targetctl messages are supported on it. Attaching
both runctl and targetctl to the node IPC channel causes every message
to received by both... which goes poorly.
