### PR TITLE
Allow --metrics and --no-profile at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,12 +187,15 @@ Runner options:
   --no-timestamp-supervisor
                      Disable timestamping of supervisor log messages.
   --syslog           Send supervisor and collected worker logs to syslog(3).
-  --metrics STATS    Send metrics to local collector (default is StrongOps)
+  --metrics STATS    Send metrics to local collector (default is not to)
   -p,--pid FILE      Write supervisor's pid to FILE, failing if FILE
                      already has a valid pid in it (default is not to).
   --cluster N        Set the cluster size (default is off, but see below).
-  --no-profile       Do not profile with StrongOps (default is to profile
-                     if registration data is found).
+  --no-profile       Disable reporting profile data to StrongOps (default
+                     is to profile if registration data is found). Does
+                     not affect local reporting using --metrics option.
+  --no-channel       Do not listen for run-time control messages (default
+                     is to listen on "runctl" when clustered).
 
 Log FILE is a path relative to the app's working directory if it is not
 absolute. To create a log file per process, FILE supports simple

--- a/bin/sl-run.js
+++ b/bin/sl-run.js
@@ -20,8 +20,10 @@ if(!config.profile) {
     quiet: config.isWorker, // Quiet in worker, to avoid repeated log messages
     logger: config.logger,
   });
-  config.sendMetrics();
 }
+
+// starts metrics reporting if --metrics was set, or does nothing
+config.sendMetrics();
 
 if((config.clustered && config.isMaster) || config.detach){
   return config.start();

--- a/lib/options.js
+++ b/lib/options.js
@@ -36,12 +36,13 @@ exports.HELP = [
   (syslogAvailable ?
   '  --syslog           Send supervisor and collected worker logs to syslog(3).'
   : null),
-  '  --metrics STATS    Send metrics to local collector (default is StrongOps)',
+  '  --metrics STATS    Send metrics to local collector (default is not to)',
   '  -p,--pid FILE      Write supervisor\'s pid to FILE, failing if FILE',
   '                     already has a valid pid in it (default is not to).',
   '  --cluster N        Set the cluster size (default is off, but see below).',
-  '  --no-profile       Do not profile with StrongOps (default is to profile',
-  '                     if registration data is found).',
+  '  --no-profile       Disable reporting profile data to StrongOps (default',
+  '                     is to profile if registration data is found). Does',
+  '                     not affect local reporting using --metrics option.',
   //XXX add --channel ADDR
   '  --no-channel       Do not listen for run-time control messages (default',
   '                     is to listen on "runctl" when clustered).',


### PR DESCRIPTION
The --no-profile option only disables StrongOps reporting instead of
disabling strong-agent entirely.

SLN-1163 #resolves

@sam-github I was doing a 5 minute look into what this would take and I think that ended up being the entire fix. Did I miss something?

/cc @chandadharap @cgole 
