### PR TITLE
test: skip object tracking test

### DIFF
--- a/test/test-runctl-object-tracking.js
+++ b/test/test-runctl-object-tracking.js
@@ -3,6 +3,11 @@ var helper = require('./helper');
 
 if (helper.skip()) return;
 
+if (!process.env.STRONGLOOP_LICENSE) {
+  console.log('ok 1 # skip because no license to run object-tracking');
+  process.exit(0);
+}
+
 var rc = helper.runCtl;
 var supervise = rc.supervise;
 var expect = rc.expect;


### PR DESCRIPTION
Object tracking requires a license to be set in the environment. Skip
the test if the license isn't present.

/to @rmg 

Depends on https://github.com/strongloop/strongops/pull/189
