### PR TITLE
test: cpu profiling now works on v0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "debug": "~1.0.0",
     "dotenv": "~0.2.8",
     "posix-getopt": "^1.1.0",
-    "strong-agent": "^1.0.0",
+    "strong-agent": "^1.0.3",
     "strong-agent-statsd": "^1.0.0",
     "strong-cluster-control": "^1.0.0",
     "strong-control-channel": "^1.1.0",

--- a/test/test-runctl-cpu-profiling.js
+++ b/test/test-runctl-cpu-profiling.js
@@ -1,9 +1,5 @@
 // test sl-runctl start/stop cpu profiling
-//
-// Profiling is not supported on node < v0.11, so this test checks it works,
-// or does not work, as would be expected with the current node version.
 var helper = require('./helper');
-var supported = require('semver').gt(process.version, '0.11.0');
 
 if (helper.skip()) return;
 
@@ -30,24 +26,14 @@ expect('set-size 1');
 waiton('status', /worker count: 1/);
 expect('status', /worker id 1:/);
 
-if (supported) {
-  expect('cpu-start 0', /Profiler started/);
-  expect('cpu-start 1', /Profiler started/);
-} else {
-  failon('cpu-start 0', /CPU profiler unavailable/);
-  failon('cpu-start 1', /CPU profiler unavailable/);
-}
+expect('cpu-start 0', /Profiler started/);
+expect('cpu-start 1', /Profiler started/);
 failon('cpu-start 6', /6 not found/);
 
 pause(2);
 
-if (supported) {
-  expect('cpu-stop 0 file-name', /CPU profile.*file-name.cpuprofile/);
-  expect('cpu-stop 1', /CPU profile.*node.1.cpuprofile/);
-} else {
-  failon('cpu-stop 0 file-name', /CPU profiler unavailable/);
-  failon('cpu-stop 1', /CPU profiler unavailable/);
-}
+expect('cpu-stop 0 file-name', /CPU profile.*file-name.cpuprofile/);
+expect('cpu-stop 1', /CPU profile.*node.1.cpuprofile/);
 failon('cpu-stop 6', /6 not found/);
 
 expect('stop');


### PR DESCRIPTION
strongloop/strongops@2ba8228b84cfbebd44e103ccb78da676a2c7b40a added cpu
profiling support for v0.10 in strong-agent v1.0.3, so remove the code
dealing with it not being supported on some node versions.

Closes https://github.com/strongloop-internal/scrum-nodeops/issues/155
