### PR TITLE
metrics: deal with app and host names with a `.`

### DIFF
--- a/lib/expander.js
+++ b/lib/expander.js
@@ -12,9 +12,9 @@ function workerParams(worker) {
     vars.w = worker.id;
   if ('pid' in worker)
     vars.p = worker.pid;
-  if ('appName' in worker)
-    vars.a = worker.appName;
-  if ('hostname' in worker)
-    vars.h = worker.hostname;
+  if ('appName' in worker) // normalize dots out of app names
+    vars.a = String(worker.appName).replace(/\./g, '-');
+  if ('hostname' in worker) // truncate hostname to first component
+    vars.h = String(worker.hostname).replace(/\..*/,'');
   return vars;
 }

--- a/test/expander.js
+++ b/test/expander.js
@@ -8,8 +8,8 @@ describe('expander.expand', function() {
   var example_worker = {
     id: 1,
     pid: 1234,
-    hostname: 'always-up',
-    appName: 'totally-awesome',
+    hostname: 'always-up.some.domain',
+    appName: 'totally.awesome',
   };
   var falsey_worker = { id: 0, pid: null, hostname: undefined, appName: false };
   var examples = [


### PR DESCRIPTION
Do not allow dots in our app or host name substitutions, they mess up
the statsd metrics hierarchy, which uses `.` as a separator.

/to @rmg I don't see a way in here to add a test easily. This is what causes strong-pm's internal metrics to not work on mac's, the `os.hostname()` usually looks like `<machine>.local`. I haven't seen an appname with a `.`, but it is possible, and would also break strong-statsd's metric name parsing.
