### PR TITLE
runctl: add timeout arg to start-cpu-profiling

### DIFF
--- a/bin/sl-runctl.js
+++ b/bin/sl-runctl.js
@@ -159,6 +159,7 @@ function requestObjectsStop(target) {
 function requestCpuStart(target) {
   request.cmd = 'start-cpu-profiling';
   request.target = requiredArg();
+  request.timeout = optionalArg(0) | 0;
   display = function(){
     console.log('Profiler started, use cpu-stop to get profile.');
   };

--- a/bin/sl-runctl.usage
+++ b/bin/sl-runctl.usage
@@ -17,7 +17,11 @@ Commands:
   objects-stop <ID>          Stop tracking objects on ID.
       Object metrics are published, see the `--metrics` option to `slc run`.
 
-  cpu-start <ID>             Start CPU profiling on ID.
+  cpu-start <ID> [TIMEOUT]   Start CPU profiling on ID.
+      TIMEOUT is the optional watchdog timeout, in milliseconds.  In watchdog
+      mode, the profiler is suspended until an event loop stall is detected;
+      i.e. when a script is running for too long.  Only supported on Linux.
+
   cpu-stop <ID> [NAME]       Stop CPU profiling on ID, save as "NAME.cpuprofile".
       CPU profiles must be loaded into Chrome Dev Tools. The NAME is optional,
       profiles default to being named `node.<PID>.cpuprofile`.

--- a/lib/targetctl.js
+++ b/lib/targetctl.js
@@ -95,7 +95,7 @@ function onRequest(req, callback) {
 
       // CPU Profiling
       case 'start-cpu-profiling':
-        agent.metrics.startCpuProfiling();
+        agent.metrics.startCpuProfiling(req.timeout);
         rsp.notify = {
           id: worker.id,
           pid: worker.pid,


### PR DESCRIPTION
Add a timeout argument to the start-cpu-profiling command that starts
the profiler in watchdog mode.  Depends on strongloop/strongops#221.

R=@sam-github, /cc @chandadharap
