### PR TITLE
test: check cpu hit counts >= 1

### DIFF
--- a/test/test-ipcctl-notifications.js
+++ b/test/test-ipcctl-notifications.js
@@ -97,7 +97,9 @@ function hitCount(filename) {
 
   var data = fs.readFileSync(__dirname + '/v1-app/' + filename, 'utf8');
   var root = JSON.parse(data);
-  return visit(root.head);
+  var count = visit(root.head);
+  debug('count %d from:', count, util.inspect(root, {depth: null}));
+  return count;
 }
 
 function startCpuProfiling(cb) {
@@ -149,7 +151,7 @@ function stopCpuProfilingWatchdog(cb) {
   var req = {cmd: 'stop-cpu-profiling', target: 1, filePath: 'test.cpuprofile'};
   ctl.request(req, function(rsp) {
     assert(!rsp.error);
-    assert.equal(hitCount(rsp.filePath), 1);
+    assert(hitCount(rsp.filePath) >= 1);
   });
 }
 


### PR DESCRIPTION
The test that they are exactly 1 seems fragile, they are usually 2 in my
environment.
