### PR TITLE
run,runctl: control options consistent with pm

### DIFF
--- a/bin/sl-run.txt
+++ b/bin/sl-run.txt
@@ -31,8 +31,9 @@ Options:
   --no-profile       Disable reporting profile data to StrongOps (default is to
 		       profile if registration data is found). Does not affect
 		       local reporting using --metrics option.
-  --no-channel       Do not listen for run-time control messages (default is to
-                       listen on "runctl" when clustered).
+  -C,--control CTL   Listen for local control messages on CTL (default `pmctl),
+                       only supported when clustered.
+  --no-control       Do not listen for local control messages.
 
 Log FILE is a path relative to the app's working directory if it is not
 absolute. To create a log file per process, FILE supports simple substitutions

--- a/bin/sl-runctl.js
+++ b/bin/sl-runctl.js
@@ -33,6 +33,7 @@ var parser = new Parser([
     'h(help)',
     'p:(path)',
     'p:(port)',
+    'C:(control)',
   ].join(''), argv);
 
 while ((option = parser.getopt()) !== undefined) {
@@ -44,6 +45,7 @@ while ((option = parser.getopt()) !== undefined) {
       console.log(HELP);
       process.exit(0);
     case 'p':
+    case 'C':
       ADDR = option.optarg;
       break;
     default:

--- a/bin/sl-runctl.txt
+++ b/bin/sl-runctl.txt
@@ -2,9 +2,9 @@ usage: %MAIN% [options] [command ...]
 
 Options:
 
-  -h,--help       Print this message and exit.
-  -v,--version    Print version and exit.
-  -p,--path,--port <path> Path or port of control socket, defaults to %ADDR%.
+  -h,--help           Print this message and exit.
+  -v,--version        Print version and exit.
+  -C,--control <CTL>  Control endpoint for process runner (default `%ADDR%`).
 
 Commands:
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -92,9 +92,9 @@ exports.parse = function parse(argv) {
     else if(/^--pid=/.test(option)) {
       // '--pid=' is the same as option not present
       (function() {
-        var file = /^--pid=(.*)/.exec(option)[1];
-        if(file != '') {
-          options.pid = file;
+        var opt = /^--pid=(.*)/.exec(option)[1];
+        if(opt != '') {
+          options.pid = opt;
         }
       })();
     }
@@ -104,15 +104,34 @@ exports.parse = function parse(argv) {
     else if(option === '--no-profile') {
       options.profile = false;
     }
-    else if(option === '--no-channel') {
-      options.channel = false;
+    else if(option === '--cluster') {
+      i++;
     }
-    else if({'--cluster':1,'--port':1,'--addr':1,'--path':1}[option]) {
-      i++; // Consume the option's argument
-    }
-    else if(/^--(cluster|port|addr|path)=/.test(option)) {
+    else if(/^--cluster=/.test(option)) {
     }
     else if(option === '--no-cluster') {
+    }
+    // Only -C,--control,--no-control are documented, now, to align with
+    // strong-pm. The others are legacy, to be deleted sometime.
+    else if({
+      '-C':1, '--control':1, '--port':1, '--addr':1, '--path':1
+    }[option]) {
+      i++;
+      options.channel = argv[i];
+    }
+    else if(/^--(control|port|addr|path)=/.test(option)) {
+      (function() {
+        var opt = /^--(control|port|addr|path)=(.*)/.exec(option)[2];
+        if(opt != '') {
+          options.channel = opt;
+        }
+      })();
+    }
+    else if(option === '--no-control') {
+      options.channel = false;
+    }
+    else if(option === '--no-channel') {
+      options.channel = false;
     }
     else if (option === '--no-timestamp-workers') {
       options.timeStampWorkerLogs = false;


### PR DESCRIPTION
pm use -C, --control, --no-control to configure the local control
channel to listen on. pmctl uses -C, --control to configure the local
control channel to connect to. run/runctl now use the same options and
usage text. The older option names are still supported, though not
documented.