### PR TITLE
run: support cluster_size env for backwards compat

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -32,7 +32,9 @@ exports.parse = function parse(argv) {
     timeStampSupervisorLogs: true,
     syslog: false,
   };
-  var cluster = process.env.STRONGLOOP_CLUSTER;
+  // cluster_size is for compatibility with strong-cluster-control@1.x
+  var cluster = 'STRONGLOOP_CLUSTER' in process.env ?
+    process.env.STRONGLOOP_CLUSTER : process.env.cluster_size;
   if (cluster == null || cluster === '') {
     cluster = process.env.NODE_ENV === 'production' ?  'CPU' : 'off';
   }


### PR DESCRIPTION
`STRONGLOOP_CLUSTER` is the preferred name, but the old 'rc' name is supported again: `cluster_size`