### PR TITLE
snapshot: remove extra .heapsnapshot in msg

### DIFF
--- a/bin/sl-runctl.js
+++ b/bin/sl-runctl.js
@@ -189,14 +189,13 @@ function requestHeapSnapshot() {
   var name = optionalArg(util.format('node.%s', target));
   request.cmd = 'heap-snapshot';
   request.target = target;
-  // .heapdump extention Required by Chrome
-  request.filePath = path.resolve(name + '.heapdump');
+  request.filePath = path.resolve(name + '.heapsnapshot');
 
   display = function(res) {
     if (res.error) {
       return console.log('Unable to write heap to `%s`: %s', res.error);
     }
-    console.log('Heap written to `%s.heapsnapshot`, load into Chrome Dev Tools',
+    console.log('Heap written to `%s`, load into Chrome Dev Tools',
       res.filePath);
   };
 }


### PR DESCRIPTION
Log message was printing the heapsnapshot filename with an extra
.heapsnapshot appended that isn't in the actual filename.

See https://github.com/strongloop-internal/scrum-nodeops/issues/269