### PR TITLE
Forward "express:usage-record" to strong-pm

### DIFF
--- a/bin/sl-run.js
+++ b/bin/sl-run.js
@@ -28,6 +28,7 @@ if((config.clustered && config.isMaster) || config.detach){
 
 // starts metrics reporting if --metrics was set, or does nothing
 config.sendMetrics();
+config.sendExpressRecords();
 
 if(!config.clustered) {
   console.log('supervisor running without clustering (unsupervised)');

--- a/lib/config.js
+++ b/lib/config.js
@@ -11,6 +11,7 @@ var fs = require('fs');
 var open = require('fs').openSync;
 var path = require('path');
 var sendMetrics = require('./metrics');
+var sendExpressRecords = require('./express-records');
 var transformer = require('strong-log-transformer');
 var util = require('util');
 var Logger = require('./logger');
@@ -28,6 +29,7 @@ if (cluster.isWorker) {
     logger: logger,
     profile: process.env.supervisor_profile != 'false',
     sendMetrics: sendMetrics,
+    sendExpressRecords: sendExpressRecords,
   };
   return;
 }
@@ -319,6 +321,8 @@ config.start = function start() {
     control.start({ size: config.size });
   });
 
+  this.sendExpressRecords(runctl.parentCtl);
+
   function setupChildLogger(worker) {
     var tag = { pid: worker.process.pid, worker: worker.id };
     var logStream = isPerWorker
@@ -343,5 +347,10 @@ config.start = function start() {
 };
 
 config.sendMetrics = sendMetrics;
+config.sendExpressRecords = function(parentCtl) {
+  if (!this.clustered) return;
+  sendExpressRecords(parentCtl);
+};
+
 
 module.exports = config;

--- a/lib/express-records.js
+++ b/lib/express-records.js
@@ -1,0 +1,31 @@
+var agent = require('./agent');
+var cluster = require('cluster');
+var debug = require('./debug')('express-records');
+
+module.exports = function sendExpressRecords(parentCtl) {
+  if (cluster.isWorker) {
+    agent().on('express:usage-record', forwardRecordToMaster);
+    return;
+  }
+
+  if (!parentCtl) {
+    debug('parentCtl not available, all records will be discarded.');
+    return;
+  }
+
+  cluster.on('fork', function(worker) {
+    worker.on('message', function forwardToParentIfExpressRecord(msg) {
+      if (msg.cmd !== 'express:usage-record') return;
+      debug('master received', msg.record);
+      parentCtl.notify(msg);
+    });
+  });
+}
+
+function forwardRecordToMaster(record) {
+  debug('received %j', record);
+  process.send({
+    cmd: 'express:usage-record',
+    record: record
+  });
+}

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "optimist": "~0.6.0",
     "semver": "~3.0.1",
     "shelljs": "~0.3.0",
+    "strong-express-metrics": "^1.0.1",
     "tap": "~0.4.11"
   },
   "engine": {

--- a/test/express-app/package.json
+++ b/test/express-app/package.json
@@ -1,5 +1,6 @@
 {
   "name": "express-app",
   "description": "express-app",
-  "version": "0.0.0"
+  "version": "0.0.0",
+  "main": "server.js"
 }

--- a/test/express-app/server.js
+++ b/test/express-app/server.js
@@ -1,6 +1,9 @@
 var options = require('optimist').argv;
 var express = require('express');
+var metrics = require('strong-express-metrics');
+
 var app = express();
+app.use(metrics());
 
 app.configure(function(){
   app.set('port', options.port || process.env.PORT || 0);

--- a/test/helper.js
+++ b/test/helper.js
@@ -193,7 +193,7 @@ exports.runWithControlChannel = function(appWithArgs, runArgs, onMessage) {
   debug('spawn: %j', args);
 
   var c = child.spawn(process.execPath, args, options);
-  var ctl = control.attach(onMessage, c);
+  control.attach(onMessage, c);
   c.unref();
   c._channel.unref(); // There is no documented way to unref child IPC
   return c;

--- a/test/helper.js
+++ b/test/helper.js
@@ -8,6 +8,7 @@ util = require('util');
 
 // module locals
 var child = require('child_process');
+var control = require('strong-control-channel/process');
 var dgram = require('dgram');
 
 // Skip when run by mocha
@@ -164,3 +165,36 @@ function pause(secs) {
 }
 
 global.pause = pause;
+
+exports.runWithControlChannel = function(appWithArgs, runArgs, onMessage) {
+  if (onMessage == undefined && typeof runArgs === 'function') {
+    onMessage = runArgs;
+    runArgs = [];
+  }
+
+  var options = {
+   // NOTE(bajtos) We are redirecting stdout to stderr in order to keep
+   // the test output clean from diagnostic messages.
+    stdio: [0, 2, 2, 'ipc'],
+    env: util._extend({
+      SL_ENV: 'test',
+      STRONGLOOP_FLUSH_INTERVAL: 2,
+    }, process.env),
+  };
+
+  var runner = require.resolve('../bin/sl-run');
+
+  var args = [
+    runner,
+    '--no-timestamp-workers',
+    '--no-timestamp-supervisor'
+  ].concat(runArgs).concat(appWithArgs);
+
+  debug('spawn: %j', args);
+
+  var c = child.spawn(process.execPath, args, options);
+  var ctl = control.attach(onMessage, c);
+  c.unref();
+  c._channel.unref(); // There is no documented way to unref child IPC
+  return c;
+};

--- a/test/helper.js
+++ b/test/helper.js
@@ -172,6 +172,13 @@ exports.runWithControlChannel = function(appWithArgs, runArgs, onMessage) {
     runArgs = [];
   }
 
+  var ctl = path.resolve(path.dirname(appWithArgs[0]), 'runctl');
+  try {
+    fs.unlinkSync(ctl);
+  } catch(er) {
+    console.log('no `%s` to cleanup: %s', ctl, er);
+  }
+
   var options = {
    // NOTE(bajtos) We are redirecting stdout to stderr in order to keep
    // the test output clean from diagnostic messages.

--- a/test/test-run-express-records.js
+++ b/test/test-run-express-records.js
@@ -1,0 +1,35 @@
+var helper = require('./helper');
+if (helper.skip()) return;
+helper.pass = true; // Use tap, not this check.
+
+var http = require('http');
+var tap = require('tap');
+var debug = require('./debug');
+var run = helper.runWithControlChannel;
+
+tap.test('express-metrics are forwarded via parentCtl', function(t) {
+  var expressApp = require.resolve('./express-app');
+  var app = run([expressApp], ['--cluster=1'], function(data) {
+    switch (data.cmd) {
+      case 'listening':
+        sendHttpRequest(data.address.address, data.address.port);
+        break;
+
+      case 'express:usage-record':
+        t.deepEqual(data.record.request, { method: 'GET', url: '/not-found' });
+        app.kill();
+        t.end();
+        break;
+    }
+  });
+});
+
+function sendHttpRequest(host, port) {
+  http.get({ host: host, port: port, path: '/not-found' }, function(res) {
+    var content = '';
+    res.on('data', function(chunk) { content += chunk.toString(); });
+    res.on('end', function() {
+      debug('received response\n', content, '\n--end--');
+    });
+  });
+}

--- a/test/test-run-metrics.js
+++ b/test/test-run-metrics.js
@@ -37,30 +37,10 @@ tap.test('metrics', function(t) {
   t.plan(plan);
 
   function run() {
-    var options = {
-      stdio: [0, 1, 2, 'ipc'],
-      env: util._extend({
-        SL_ENV: 'test',
-        STRONGLOOP_FLUSH_INTERVAL: 2,
-      }, process.env),
-    };
-    var run = require.resolve('../bin/sl-run');
-    var app = require.resolve('./module-app');
-
-    var args = [
-      run,
-      '--no-timestamp-workers',
-      '--no-timestamp-supervisor',
-      '--cluster=1',
-      '--no-profile',
-    ].concat(runArgs).concat(app);
-
-    debug('spawn: %j', args);
-
-    var run = cp.spawn(process.execPath, args, options);
-    var ctl = control.attach(onRequest, run);
-    run.unref();
-    run._channel.unref(); // There is no documented way to unref child IPC
+    helper.runWithControlChannel(
+      require.resolve('./module-app'),
+      ['--cluster=1', '--no-profile'],
+      onRequest);
   }
 
   var internalMetrics;
@@ -180,7 +160,7 @@ tap.test('metrics', function(t) {
     debug('log: file set to `%s`', file);
 
     poll.unref();
-    
+
     runArgs.push('--metrics=' + url);
 
     plan += 1;


### PR DESCRIPTION
If we have an ipc channel to our parent, we forward express usage records (`express:usage-record`) from strong-agent to the parent.

/to @sam-github please review

Close strongloop-internal/scrum-loopback#125