### PR TITLE
Fix log tagging of statsd

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -92,7 +92,11 @@ function sendMetrics(parentCtl, callback) {
 
   if (this.setupChildLogger && server.child) {
     var statsdWorker = {
-      process: server.child,
+      process: {
+        stdout: server.child.stdout,
+        stderr: server.child.stderr,
+        pid: process.pid,
+      },
       id: 'statsd',
     };
     this.setupChildLogger(statsdWorker);


### PR DESCRIPTION
Now that statsd is being run inside the supervisor its "child" no
longer has a pid.

See #89