### PR TITLE
Support Joyent node v0.12.x and iojs

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "node": ">=0.10.0"
   },
   "optionalDependencies": {
-    "heapdump": "~0.2.10",
+    "heapdump": "^0.3.5",
     "strong-fork-syslog": "^1.2.1"
   }
 }

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,16 +1,3 @@
-// test globals
-assert = require('assert');
-debug = require('./debug');
-fs = require('fs');
-path = require('path');
-shell = require('shelljs/global');
-util = require('util');
-
-// module locals
-var child = require('child_process');
-var control = require('strong-control-channel/process');
-var dgram = require('dgram');
-
 // Skip when run by mocha
 exports.skip = function skip() {
   if ('describe' in global) {
@@ -23,6 +10,19 @@ exports.skip = function skip() {
 
 // if helper is being run directly by mocha, skip it.
 if (exports.skip()) return;
+
+// test globals
+assert = require('assert');
+debug = require('./debug');
+fs = require('fs');
+path = require('path');
+shell = require('shelljs/global');
+util = require('util');
+
+// module locals
+var child = require('child_process');
+var control = require('strong-control-channel/process');
+var dgram = require('dgram');
 
 // Assert if test does not explicitly say it passed, guards against accidental
 // exit with `0`.

--- a/test/pidfile.js
+++ b/test/pidfile.js
@@ -23,7 +23,7 @@ function unlink() {
 }
 
 function noSuchPid() {
-  var pid = 0xffffffff;
+  var pid = 0x7fffffff;
 
   while(pid > 1) {
     try {
@@ -40,7 +40,7 @@ function noSuchPid() {
 
 describe('pidfile', function() {
   beforeEach(unlink);
-  
+
   it('should create a pidfile', function() {
     create();
     assertValid();

--- a/test/supervisor-detach.js
+++ b/test/supervisor-detach.js
@@ -12,6 +12,8 @@ var exp = /^supervisor (\d+) detached process (\d+), output logged to '(\S+)'$/m
 describe('supervisor --detach', function() {
   var pids = [];
 
+  this.timeout(10000); // CI machines are slow for process creation
+
   beforeEach(function() {
     // re-using exp means resetting it after each use
     exp.lastIndex = 0;

--- a/test/supervisor.js
+++ b/test/supervisor.js
@@ -17,7 +17,7 @@ function once(fn) {
 describe('supervisor', function(done) {
   var child;
 
-  this.timeout(4000); // CI machines are slow for process creation
+  this.timeout(10000); // CI machines are slow for process creation
 
   this.afterEach(function(done) {
     process.chdir(cwd);


### PR DESCRIPTION
 * fix loop that looks for unused pids
 * upgrade heapdump to a version that works beyond node-v0.10
 * loosen test timings to account for slow VMs in CI

@bnoordhuis heapdump is yours, do you see any problems with this upgrade? Will it affect the output format?