### PR TITLE
Add --no-log-decoration option to disable worker id/pid prefixing in cluster mode

### DIFF
--- a/bin/sl-run.txt
+++ b/bin/sl-run.txt
@@ -22,6 +22,9 @@ Options:
                      Disable timestamping of worker log lines by supervisor.
   --no-timestamp-supervisor
                      Disable timestamping of supervisor log messages.
+  --no-log-decoration
+                     Disable decorating supervisor/worker log messages with
+                       cluster id/pid
   --syslog           Send supervisor and collected worker logs to syslog,
                        unsupported on Windows.
   --metrics BACKEND  Report metrics to custom backend. Implies `--profile`.

--- a/lib/config.js
+++ b/lib/config.js
@@ -189,7 +189,7 @@ supervisorLog.setMaxListeners(0);
 
 if (config.clustered) {
   logger.sink = transformer({
-    tag: options.tags ? {pid: process.pid, worker: 0} : null,
+    tag: options.logDecoration ? {pid: process.pid, worker: 0} : null,
     timeStamp: options.timeStampSupervisorLogs,
   });
   logger.sink.pipe(supervisorLog);
@@ -340,11 +340,11 @@ config.start = function start() {
                   : supervisorLog;                  // cleaned up by exit()
     var outLog = transformer({
       timeStamp: options.timeStampWorkerLogs,
-      tag: options.tags ? tag : null
+      tag: options.logDecoration ? tag : null
     });
     var errLog = transformer({
       timeStamp: options.timeStampWorkerLogs,
-      tag: options.tags ? tag : null,
+      tag: options.logDecoration ? tag : null,
       mergeLines: true
     });
     // When we have per-worker logs, each worker gets their own LogWriter, which

--- a/lib/config.js
+++ b/lib/config.js
@@ -189,7 +189,7 @@ supervisorLog.setMaxListeners(0);
 
 if (config.clustered) {
   logger.sink = transformer({
-    tag: {pid: process.pid, worker: 0},
+    tag: options.tags ? {pid: process.pid, worker: 0} : null,
     timeStamp: options.timeStampSupervisorLogs,
   });
   logger.sink.pipe(supervisorLog);
@@ -340,11 +340,11 @@ config.start = function start() {
                   : supervisorLog;                  // cleaned up by exit()
     var outLog = transformer({
       timeStamp: options.timeStampWorkerLogs,
-      tag: tag
+      tag: options.tags ? tag : null
     });
     var errLog = transformer({
       timeStamp: options.timeStampWorkerLogs,
-      tag: tag,
+      tag: options.tags ? tag : null,
       mergeLines: true
     });
     // When we have per-worker logs, each worker gets their own LogWriter, which

--- a/lib/options.js
+++ b/lib/options.js
@@ -30,7 +30,7 @@ exports.parse = function parse(argv) {
     metrics: null,
     timeStampWorkerLogs: true,
     timeStampSupervisorLogs: true,
-    tags: true,
+    logDecoration: true,
     syslog: false,
   };
   // cluster_size is for compatibility with strong-cluster-control@1.x
@@ -133,8 +133,8 @@ exports.parse = function parse(argv) {
     } else if (option === '--no-timestamp-supervisor') {
       options.timeStampSupervisorLogs = false;
 
-    } else if (option === '--no-tags') {
-      options.tags = false;
+    } else if (option === '--no-log-decoration') {
+      options.logDecoration = false;
 
     } else {
       options.argv = argv.slice(0, i);

--- a/lib/options.js
+++ b/lib/options.js
@@ -30,6 +30,7 @@ exports.parse = function parse(argv) {
     metrics: null,
     timeStampWorkerLogs: true,
     timeStampSupervisorLogs: true,
+    tags: true,
     syslog: false,
   };
   // cluster_size is for compatibility with strong-cluster-control@1.x
@@ -131,6 +132,9 @@ exports.parse = function parse(argv) {
 
     } else if (option === '--no-timestamp-supervisor') {
       options.timeStampSupervisorLogs = false;
+
+    } else if (option === '--no-tags') {
+      options.tags = false;
 
     } else {
       options.argv = argv.slice(0, i);

--- a/test/supervisor.js
+++ b/test/supervisor.js
@@ -145,6 +145,21 @@ describe('supervisor', function(done) {
     });
   });
 
+  describe('tags', function() {
+    var TAGS_WORKER = /^pid:\d+ worker:\d+ .+/;
+    var TAGS_SUPER = /^pid:\d+ worker:0 .+/;
+    var NO_TAGS = /^.+/;
+
+    describe('tag logs', function() {
+      var EXPECT_TAGS = [ TAGS_WORKER, TAGS_SUPER ];
+      var EXPECT_NO_TAGS = [ NO_TAGS, NO_TAGS ];
+
+      run('.', ['--cluster', '1', '--no-timestamp-supervisor', '--no-timestamp-workers', 'test/yes-app'], EXPECT_TAGS);
+      run('.', ['--cluster', '1', '--no-timestamp-supervisor', '--no-timestamp-workers', '--no-tags', 'test/yes-app'], EXPECT_NO_TAGS);
+    });
+
+  });
+
   describe('SIGHUP of supervisor', function() {
     it('should chdir into PWD before restarting', function(done) {
       var EXPECT = [

--- a/test/supervisor.js
+++ b/test/supervisor.js
@@ -145,7 +145,7 @@ describe('supervisor', function(done) {
     });
   });
 
-  describe('tags', function() {
+  describe('log decoration', function() {
     var TAGS_WORKER = /^pid:\d+ worker:\d+ .+/;
     var TAGS_SUPER = /^pid:\d+ worker:0 .+/;
     var NO_TAGS = /^.+/;
@@ -155,7 +155,7 @@ describe('supervisor', function(done) {
       var EXPECT_NO_TAGS = [ NO_TAGS, NO_TAGS ];
 
       run('.', ['--cluster', '1', '--no-timestamp-supervisor', '--no-timestamp-workers', 'test/yes-app'], EXPECT_TAGS);
-      run('.', ['--cluster', '1', '--no-timestamp-supervisor', '--no-timestamp-workers', '--no-tags', 'test/yes-app'], EXPECT_NO_TAGS);
+      run('.', ['--cluster', '1', '--no-timestamp-supervisor', '--no-timestamp-workers', '--no-log-decoration', 'test/yes-app'], EXPECT_NO_TAGS);
     });
 
   });


### PR DESCRIPTION
This addresses #99 