### PR TITLE
Add env-get/set/unset runctl commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ defaults to "CPUs".
 
 ```
 usage: slc runctl [options] [command ...]
-usage: slrc [options] [command]
+usage: sl-runctl [options] [command]
 
 Options:
 
@@ -283,6 +283,11 @@ Commands:
 
   patch <ID> <FILE>          Apply patch FILE to ID.
 
+  env-set <K1=V1...>         Set environment variables in master and worker.
+                             Changes are live without process restart.
+
+  env-unset <KEYS...>        Unset environment variables in master and workers.
+                             Changes are live without process restart.
 
 Commands specific to a worker ID accept either a process ID or cluster worker
 ID, and use an ID of `0` to mean the cluster master.

--- a/README.md
+++ b/README.md
@@ -283,6 +283,10 @@ Commands:
 
   patch <ID> <FILE>          Apply patch FILE to ID.
 
+  env-get [ID]               Get the complete environment of the specified
+                             process. If no target is specified the default is 0,
+                             the cluster master process.
+
   env-set <K1=V1...>         Set environment variables in master and worker.
                              Changes are live without process restart.
 

--- a/bin/sl-runctl.js
+++ b/bin/sl-runctl.js
@@ -91,6 +91,8 @@ var commands = {
   'cpu-stop': requestCpuStop,
   'heap-snapshot': requestHeapSnapshot,
   patch: requestPatch,
+  'env-set': requestEnvSet,
+  'env-unset': requestEnvUnSet,
 };
 
 var action = commands[command] || invalidCommand;
@@ -210,6 +212,22 @@ function requestPatch() {
   request.cmd = 'patch';
   request.target = target;
   request.patch = JSON.parse(fs.readFileSync(file));
+}
+
+function requestEnvSet() {
+  request.cmd = 'env-set';
+  request.env = {};
+  argv.slice(optind++).forEach(function(kv) {
+    var pair = kv.split('=').map(function(p) { return p.trim(); });
+    if (pair[0]) {
+      request.env[pair[0]] = pair[1];
+    }
+  });
+}
+
+function requestEnvUnSet() {
+  request.cmd = 'env-unset';
+  request.env = argv.slice(optind++);
 }
 
 debug('addr: %j, request: %j', ADDR, request);

--- a/bin/sl-runctl.js
+++ b/bin/sl-runctl.js
@@ -91,6 +91,7 @@ var commands = {
   'cpu-stop': requestCpuStop,
   'heap-snapshot': requestHeapSnapshot,
   patch: requestPatch,
+  'env-get': requestEnvGet,
   'env-set': requestEnvSet,
   'env-unset': requestEnvUnSet,
 };
@@ -212,6 +213,20 @@ function requestPatch() {
   request.cmd = 'patch';
   request.target = target;
   request.patch = JSON.parse(fs.readFileSync(file));
+}
+
+function requestEnvGet() {
+  request.target = optionalArg(0) | 0;
+  request.cmd = 'env-get';
+  display = function dumpEnv(rsp) {
+    if (rsp.error || !rsp.env) {
+      console.error('Unable to get env:', rsp.error || 'unknown');
+    } else {
+      Object.keys(rsp.env).sort().forEach(function(k) {
+        console.log('%s=%s', k, rsp.env[k]);
+      });
+    }
+  }
 }
 
 function requestEnvSet() {

--- a/bin/sl-runctl.txt
+++ b/bin/sl-runctl.txt
@@ -33,6 +33,11 @@ Commands:
 
   patch <ID> <FILE>          Apply patch FILE to ID.
 
+  env-set <K1=V1...>         Set environment variables in master and worker.
+                             Changes are live without process restart.
+
+  env-unset <KEYS...>        Unset environment variables in master and workers.
+                             Changes are live without process restart.
 
 Commands specific to a worker ID accept either a process ID or cluster worker
 ID, and use an ID of `0` to mean the cluster master.

--- a/bin/sl-runctl.txt
+++ b/bin/sl-runctl.txt
@@ -33,6 +33,10 @@ Commands:
 
   patch <ID> <FILE>          Apply patch FILE to ID.
 
+  env-get [ID]               Get the complete environment of the specified
+                             process. If no target is specified the default is 0,
+                             the cluster master process.
+
   env-set <K1=V1...>         Set environment variables in master and worker.
                              Changes are live without process restart.
 

--- a/lib/runctl.js
+++ b/lib/runctl.js
@@ -147,14 +147,12 @@ function onRequest(req, callback) {
 
   } else if (cmd === 'env-set') {
     for (var k in req.env) {
-      console.log('master set %s=%s', k, req.env[k]);
       process.env[k] = req.env[k];
     }
     rsp = requestAllTargets(req, callback);
 
   } else if (cmd === 'env-unset') {
     for (var k in req.env) {
-      console.log('master unset %s', req.env[k]);
       delete process.env[req.env[k]];
     }
     rsp = requestAllTargets(req, callback);

--- a/lib/runctl.js
+++ b/lib/runctl.js
@@ -1,5 +1,6 @@
 // run-time control channel
 var agent = require('./agent');
+var async = require('async');
 var cluster = require('cluster');
 var debug = require('./debug')('runctl');
 var fs = require('fs');
@@ -144,6 +145,20 @@ function onRequest(req, callback) {
     rsp.workerID = child.workerID;
     rsp.processID = child.process.pid;
 
+  } else if (cmd === 'env-set') {
+    for (var k in req.env) {
+      console.log('master set %s=%s', k, req.env[k]);
+      process.env[k] = req.env[k];
+    }
+    rsp = requestAllTargets(req, callback);
+
+  } else if (cmd === 'env-unset') {
+    for (var k in req.env) {
+      console.log('master unset %s', req.env[k]);
+      delete process.env[req.env[k]];
+    }
+    rsp = requestAllTargets(req, callback);
+
   } else {
     // Pass any others off to the target
     rsp = requestOfTarget(req, rsp, callback);
@@ -151,6 +166,29 @@ function onRequest(req, callback) {
 
   if (callback && rsp) {
     process.nextTick(callback.bind(null, rsp));
+  }
+}
+
+function requestAllTargets(req, callback) {
+  console.log('forwarding to all workers:', req);
+  var wIds = [];
+  for (var w in cluster.workers) {
+    wIds.push(cluster.workers[w].id);
+  }
+  async.map(wIds, forwardToWorker, makeResponse);
+  return null;
+
+  function forwardToWorker(wid, next) {
+    var wreq = JSON.parse(JSON.stringify(req));
+    wreq.target = wid;
+    console.log('forwarding %j', wreq);
+    requestOfTarget(wreq, {}, function(rsp) {
+      next(null, rsp);
+    });
+  }
+
+  function makeResponse(err, res) {
+    callback(res);
   }
 }
 

--- a/lib/runctl.js
+++ b/lib/runctl.js
@@ -140,7 +140,6 @@ function onRequest(req, callback) {
     cluster.disconnect();
 
   } else if (cmd === 'fork') {
-    cluster.fork();
     var child = cluster.fork();
     rsp.workerID = child.workerID;
     rsp.processID = child.process.pid;

--- a/lib/targetctl.js
+++ b/lib/targetctl.js
@@ -136,6 +136,10 @@ function onRequest(req, callback) {
 
         break;
 
+      case 'env-get':
+        rsp.env = process.env;
+        break;
+
       case 'env-set':
         for (var k in req.env) {
           console.log('worker set %s=%s', k, req.env[k]);

--- a/lib/targetctl.js
+++ b/lib/targetctl.js
@@ -136,6 +136,20 @@ function onRequest(req, callback) {
 
         break;
 
+      case 'env-set':
+        for (var k in req.env) {
+          console.log('worker set %s=%s', k, req.env[k]);
+          process.env[k] = req.env[k];
+        }
+        break;
+
+      case 'env-unset':
+        for (var k in req.env) {
+          console.log('master unset %s', req.env[k]);
+          delete process.env[req.env[k]];
+        }
+        break;
+
       // Unsupported
       default:
         rsp.error = 'unsupported';

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "async": "~0.9.0",
+    "byline": "^4.2.1",
     "eslint": "^0.17.0",
     "express": "~3.2.4",
     "jscs": "^1.11.3",

--- a/test/env-app/index.js
+++ b/test/env-app/index.js
@@ -1,0 +1,19 @@
+var envs = process.argv.slice(2);
+
+var i = setInterval(dump, 500);
+
+process.on('internalMessage', function(msg) {
+  if(msg && msg.cmd && msg.cmd === 'NODE_CLUSTER_disconnect') {
+    // v0.10
+    clearInterval(i);
+  }
+  if(msg && msg.cmd && msg.cmd === 'NODE_CLUSTER' && msg.act === 'disconnect') {
+    // v0.11
+    clearInterval(i);
+  }
+});
+
+function dump() {
+  var current = envs.map(function(k) { return k + '=' + process.env[k]; });
+  console.log(current.join(' '));
+}

--- a/test/env-app/index.js
+++ b/test/env-app/index.js
@@ -1,3 +1,4 @@
+process.env.ENV_TEST_APP = __dirname;
 var envs = process.argv.slice(2);
 
 var i = setInterval(dump, 500);

--- a/test/env-app/package.json
+++ b/test/env-app/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "env-app",
+  "version": "0.0.0",
+  "description": "Like env and yes combined",
+  "main": "index.js"
+}

--- a/test/test-runctl-env.js
+++ b/test/test-runctl-env.js
@@ -1,0 +1,115 @@
+var byline = require('byline');
+var child = require('child_process');
+var debug = require('debug')('runctl-test');
+var helper = require('./helper');
+
+if (helper.skip()) return;
+
+var test = require('tap').test;
+
+test('environment controls', function(t) {
+  var app = require.resolve('./env-app');
+  var run = supervise(app, ['SL_T1', 'SL_T2', 'SL_T3']);
+
+  // supervisor should exit with 0 after we stop it
+  run.on('exit', function(code, signal) {
+    assert.equal(code, 0);
+    helper.pass = true;
+  });
+
+  t.test('initial', function(tt) {
+    run.says(tt, /^SL_T1=undefined SL_T2=undefined SL_T3=undefined$/);
+  });
+
+  t.test('env-set single', function(tt) {
+    run.ctl(tt, 'env-set', ['SL_T1=hereIam']);
+    run.says(tt, /^SL_T1=hereIam SL_T2=undefined SL_T3=undefined$/);
+  });
+
+  t.test('env-set multiple', function(tt) {
+    run.ctl(tt, 'env-set', ['SL_T1=newVal', 'SL_T2=2ndVal', 'SL_T3=three']);
+    run.says(tt, /^SL_T1=newVal SL_T2=2ndVal SL_T3=three$/);
+  });
+
+  t.test('env-unset single', function(tt) {
+    run.ctl(tt, 'env-unset', ['SL_T1']);
+    run.says(tt, /^SL_T1=undefined SL_T2=2ndVal SL_T3=three$/);
+  });
+
+  t.test('env-unset multiple', function(tt) {
+    run.ctl(tt, 'env-unset', ['SL_T2', 'SL_T3']);
+    run.says(tt, /^SL_T1=undefined SL_T2=undefined SL_T3=undefined$/);
+  });
+
+  t.test('exit', function(tt) {
+    run.ctl(tt, 'stop');
+    tt.end();
+  });
+});
+
+// run supervisor
+function supervise(app, vars) {
+  var run = require.resolve('../bin/sl-run');
+  var ctl = path.join(app, '..', 'runctl');
+  var cleanLogArgs = [
+    '--no-timestamp-workers',
+    '--no-timestamp-supervisor',
+    '--no-log-decoration',
+  ];
+  var appAndArgs = [app].concat(vars);
+  var args = ['--control', ctl, '--cluster=1'].concat(cleanLogArgs);
+  try {
+    fs.unlinkSync(ctl);
+  } catch (er) {
+    console.log('no `%s` to cleanup: %s', ctl, er);
+  }
+
+  console.log('# supervise %s with %j', run, args);
+
+  var c = child.fork(run, args.concat(appAndArgs), {silent: true});
+
+  // don't let it live longer than us!
+  // XXX(sam) once sl-runctl et. al. self-exit on loss of parent, we
+  // won't need this, but until then...
+  process.on('exit', c.kill.bind(c));
+  function die() {
+    c.kill();
+    process.kill(process.pid, 'SIGTERM');
+  }
+  process.once('SIGTERM', die);
+  process.once('SIGINT', die);
+
+  c.ctl = runctl;
+  c.says = says;
+
+  return c;
+
+  function runctl(t, cmd, cmdArgs) {
+    var runctljs = require.resolve('../bin/sl-runctl');
+    var args = [runctljs, '--control', ctl, cmd].concat(cmdArgs);
+    child.execFile(process.execPath, args, function(err, stdout, stderr) {
+      debug('# runctl %s %j: ', cmd, args, err, stdout, stderr);
+      t.ifError(err, ['sl-runctl', cmd].concat(cmdArgs).join(' '));
+    });
+  }
+
+  function says(t, pat) {
+    var watcher = byline.createStream();
+    var found = false;
+    debug('# watching for: ', pat);
+    watcher.on('data', function(line) {
+      if (!found && pat.test(line)) {
+        found = true;
+        c.stdout.unpipe(watcher);
+      } else {
+        debug('# > %s', line);
+      }
+    });
+    watcher.on('unpipe', function() {
+      t.ok(found, 'saw '+ pat);
+      debug('# unpiped!');
+      t.end();
+    });
+    c.stdout.pipe(watcher);
+  }
+}


### PR DESCRIPTION
Allows live setting and unsetting of environment variables.
* [x] Apply environment change to master
* [x] Apply environment change to all running workers
* [x] Apply new environment to future forked workers

Connects to strongloop-internal/scrum-nodeops#303