### PR TITLE
Send notifications to connected runctl clients

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -251,9 +251,7 @@ config.start = function start() {
   require('strong-cluster-control');
 
   control.on('start', function() {
-    if (runctl.notifyStarted) {
-      runctl.notifyStarted();
-    }
+    runctl.notifyStarted();
 
     if (!options.channel) return;
 

--- a/lib/express-records.js
+++ b/lib/express-records.js
@@ -8,11 +8,6 @@ module.exports = function sendExpressRecords(parentCtl) {
     return;
   }
 
-  if (!parentCtl) {
-    debug('parentCtl not available, all records will be discarded.');
-    return;
-  }
-
   cluster.on('fork', function(worker) {
     worker.on('message', function forwardToParentIfExpressRecord(msg) {
       if (msg.cmd !== 'express:usage-record') return;

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -45,7 +45,7 @@ function sendMetrics(parentCtl, callback) {
     }
   }
 
-  if (process.send && cluster.isMaster) {
+  if (cluster.isMaster) {
     endpoints.push('internal:');
   }
 
@@ -112,9 +112,7 @@ function sendMetrics(parentCtl, callback) {
 
   function forwardMetrics(metrics) {
     debug('received: %j', metrics);
-
-    if (parentCtl)
-      parentCtl.notify({cmd: 'metrics', metrics: injectIdentifiers(metrics)});
+    parentCtl.notify({cmd: 'metrics', metrics: injectIdentifiers(metrics)});
   }
 
   return true;

--- a/lib/runctl.js
+++ b/lib/runctl.js
@@ -12,27 +12,37 @@ var util = require('util');
 exports.start = start;
 exports.onRequest = onRequest; // For testing
 
+var ctlChannel = {
+  notify: function notify(req) {
+    if (ipcctl) {
+      ipcctl.notify(req);
+    }
+    server.notify(req);
+  },
+};
 // Expose runctl using local domain server
 var server = require('strong-control-channel/server').create(onRequest);
 
 // Expose runctl using node IPC only in the master/supervisor (workers
 // attach targetctl to the master).
-
+var ipcctl = null;
 if (cluster.isMaster && process.send) {
-  var ipcctl = require('strong-control-channel/process').attach(onRequest);
-  var agentVersion = require('strong-agent/package.json').version;
+  ipcctl = require('strong-control-channel/process').attach(onRequest);
+}
 
+if (cluster.isMaster) {
+  var agentVersion = require('strong-agent/package.json').version;
   exports.notifyStarted = function() {
     // Must not be done synchronously in the require, we don't know the app name
     // until after run has found the app, and change to its directory.
-
-    ipcctl.notify({
+    ctlChannel.notify({
       cmd: 'started',
       pid: process.pid,
       pst: master.startTime,
       appName: agent().config.appName,
       agentVersion: agentVersion,
     });
+
     // Status notifications usually come after every fork and exit, but if there
     // are no forks, we still want at least one status notification sent. Note
     // that size may be undefined, which isn't > or < than 1.
@@ -43,8 +53,7 @@ if (cluster.isMaster && process.send) {
 
   cluster.on('listening', function(worker, address) {
     debug('listening');
-
-    ipcctl.notify({
+    ctlChannel.notify({
       cmd: 'listening',
       id: worker.id,
       pid: worker.process.pid,
@@ -53,12 +62,11 @@ if (cluster.isMaster && process.send) {
     });
   });
 
-  exports.parentCtl = ipcctl;
+  exports.parentCtl = ctlChannel;
 
   master.on('fork', function(worker) {
     debug('fork');
-
-    ipcctl.notify({
+    ctlChannel.notify({
       cmd: 'fork',
       id: worker.id,
       pid: worker.process.pid,
@@ -68,7 +76,7 @@ if (cluster.isMaster && process.send) {
   });
 
   cluster.on('exit', function(worker, code, signal) {
-    ipcctl.notify({
+    ctlChannel.notify({
       cmd: 'exit',
       id: worker.id,
       pid: worker.process.pid,
@@ -82,8 +90,7 @@ if (cluster.isMaster && process.send) {
   function notifyStatus() {
     var status = master.status();
     status.cmd = 'status';
-
-    ipcctl.notify(status);
+    ctlChannel.notify(status);
   }
 }
 
@@ -224,10 +231,10 @@ function requestOfTarget(req, rsp, callback) {
     // add pst field in master since workers don't know their own pst
     var target = cluster.workers[+rsp.target] || master;
     rsp.pst = target.startTime;
-    if (ipcctl && rsp.notify) {
-      ipcctl.notify(rsp.notify);
+    if (rsp.notify) {
+      ctlChannel.notify(rsp.notify);
+      delete rsp.notify;
     }
-    delete rsp.notify;
 
     callback(rsp);
   }

--- a/lib/status-wd.js
+++ b/lib/status-wd.js
@@ -20,8 +20,6 @@ module.exports = function(parentCtl) {
     return;
   }
 
-  if (!parentCtl) return;
-
   master.on('fork', function(worker) {
     worker.on('message', function(msg) {
       if (msg.cmd !== 'status:wd') return;

--- a/lib/trace-object.js
+++ b/lib/trace-object.js
@@ -23,11 +23,6 @@ exports.sendTraceObject = function sendTraceObject(parentCtl) {
     return;
   }
 
-  if (!parentCtl) {
-    debug('parentCtl not available, all trace objects will be discarded.');
-    return;
-  }
-
   cluster.on('fork', function(worker) {
     worker.on('message', function forwardToParentIfTraceObject(msg) {
       if (msg.cmd !== 'trace:object') return;

--- a/lib/traces.js
+++ b/lib/traces.js
@@ -25,11 +25,6 @@ module.exports = function sendTraces(parentCtl) {
     return;
   }
 
-  if (!parentCtl) {
-    debug('parentCtl not available, all traces will be discarded.');
-    return;
-  }
-
   master.on('fork', function(worker) {
     worker.on('message', function(msg) {
       if (msg.cmd !== 'agent:trace') return;

--- a/test/metrics.js
+++ b/test/metrics.js
@@ -18,10 +18,6 @@ describe('metrics', function() {
     delete process.env.STRONGLOOP_METRICS;
   });
 
-  it('returns false when STRONGLOOP_METRICS not in env', function() {
-    assert.equal(metrics.send(), false);
-  });
-
   it.skip('returns true when STRONGLOOP_METRICS is statsd', function() {
     // XXX(sam) This passes, but somehow pollutes the global mocha environment
     // so the supervisor/loopback tests fail. Not the supervisor/express, just


### PR DESCRIPTION
Any client connected to us via TCP should also be "subscribed" to
cluster/app related events.