### PR TITLE
don't load cluster-only features when unclustered

### DIFF
--- a/bin/sl-run.js
+++ b/bin/sl-run.js
@@ -60,13 +60,14 @@ if (config.enableTracing) {
   tracer(traceObject.tracerOptions);
 }
 
-config.sendExpressRecords();
 config.sendMetrics();
-config.sendStatusWd();
-config.sendTraceObject();
-config.sendTraces();
 
-if (!config.clustered) {
+if (config.clustered) {
+  config.sendExpressRecords();
+  config.sendStatusWd();
+  config.sendTraceObject();
+  config.sendTraces();
+} else {
   console.log('supervisor running without clustering (unsupervised)');
 }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -381,16 +381,9 @@ config.start = function start() {
 
 config.sendMetrics = sendMetrics;
 config.sendStatusWd = sendStatusWd;
-config.sendExpressRecords = function(parentCtl) {
-  if (!this.clustered) return;
-  sendExpressRecords(parentCtl);
-};
-config.sendTraces = function(parentCtl) {
-  if (!this.clustered) return;
-  sendTraces(parentCtl);
-};
+config.sendExpressRecords = sendExpressRecords;
+config.sendTraces = sendTraces;
 config.sendTraceObject = function(parentCtl) {
-  if (!this.clustered) return;
   if (!this.enableTracing) {
     debug('tracing is disabled.');
     return;

--- a/lib/express-records.js
+++ b/lib/express-records.js
@@ -6,6 +6,8 @@ module.exports = function sendExpressRecords(parentCtl) {
   if (cluster.isWorker) {
     agent().on('express:usage-record', forwardRecordToMaster);
     return;
+  } else if (!parentCtl) {
+    return;
   }
 
   cluster.on('fork', function(worker) {

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -77,7 +77,9 @@ function sendMetrics(parentCtl, callback) {
 
   // Internal metrics support, forwarded over node ipc from cluster master
   // to parent.
-  server.on('metrics', forwardMetrics);
+  if (parentCtl) {
+    server.on('metrics', forwardMetrics);
+  }
 
   server.start(function(er) {
     assert.ifError(er);

--- a/lib/status-wd.js
+++ b/lib/status-wd.js
@@ -18,6 +18,8 @@ module.exports = function(parentCtl) {
       process.send(wd);
     });
     return;
+  } else if (!parentCtl) {
+    return;
   }
 
   master.on('fork', function(worker) {

--- a/lib/trace-object.js
+++ b/lib/trace-object.js
@@ -21,6 +21,8 @@ exports.sendTraceObject = function sendTraceObject(parentCtl) {
             'perhaps, need license.', cluster.worker.id);
     }
     return;
+  } else if (!parentCtl) {
+    return;
   }
 
   cluster.on('fork', function(worker) {

--- a/lib/traces.js
+++ b/lib/traces.js
@@ -23,6 +23,8 @@ module.exports = function sendTraces(parentCtl) {
       }
     });
     return;
+  } else if (!parentCtl) {
+    return;
   }
 
   master.on('fork', function(worker) {


### PR DESCRIPTION
There is no need, and a side effect was that some of the code assumed
it was only called in clustered mode, so it was missing guards for
checking that it was running in clustered mode.

Connect to strongloop-internal/scrum-nodeops#550