### PR TITLE
Upgrade tests to use tap@1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "lint": "eslint . && jscs .",
     "pretest": "npm run lint",
-    "test": "tap --bail test/test-*.js"
+    "test": "tap --bail --timeout 300 test/test-*.js"
   },
   "dependencies": {
     "async": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "lint": "eslint . && jscs .",
     "pretest": "npm run lint",
-    "test": "tap test/test-*.js"
+    "test": "tap --bail test/test-*.js"
   },
   "dependencies": {
     "async": "^0.9.0",
@@ -64,7 +64,7 @@
     "semver": "~3.0.1",
     "shelljs": "~0.3.0",
     "strong-express-metrics": "^1.0.1",
-    "tap": "~0.7.0"
+    "tap": "^1.0.2"
   },
   "engine": {
     "node": ">=0.10.0"

--- a/test/helper.js
+++ b/test/helper.js
@@ -41,7 +41,7 @@ exports.statsd = function statsd(callback) {
   server.reported = [];
 
   server.on('message', function(data) {
-    console.log('statsd receives metric: %s', data);
+    console.log('# statsd receives metric: %s', data);
     server.reported.push(data.toString());
   });
 
@@ -64,7 +64,7 @@ exports.statsd = function statsd(callback) {
   };
 
   function listening(er) {
-    console.log('statsd listening:', er || server.address());
+    console.log('# statsd listening:', er || server.address());
     assert.ifError(er);
     server.port = server.address().port;
     return callback(server);
@@ -85,12 +85,12 @@ function supervise(app, args) {
   try {
     fs.unlinkSync(ctl);
   } catch (er) {
-    console.log('no `%s` to cleanup: %s', ctl, er);
+    console.log('# no `%s` to cleanup: %s', ctl, er);
   }
 
   args = ['--cluster=0'].concat(args || []).concat([app]);
 
-  console.log('supervise %s with %j', run, args);
+  console.log('# supervise %s with %j', run, args);
 
   var c = child.fork(run, args);
 
@@ -148,7 +148,7 @@ function runctl(cmd) {
     require.resolve('../bin/sl-runctl'),
     cmd || ''
   ));
-  console.log('runctl %s =>', cmd, out);
+  console.log('# runctl %s =>', cmd, out.output.split('\n').join('\n # '));
   return out;
 }
 
@@ -174,7 +174,7 @@ exports.runWithControlChannel = function(appWithArgs, runArgs, onMessage) {
   try {
     fs.unlinkSync(ctl);
   } catch (er) {
-    console.log('no `%s` to cleanup: %s', ctl, er);
+    console.log('# no `%s` to cleanup: %s', ctl, er);
   }
 
   var options = {

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,16 +1,3 @@
-// Skip when run by mocha
-exports.skip = function skip() {
-  if ('describe' in global) {
-    describe(module.parent.filename, function() {
-      it.skip('run test with tap, not mocha', function(){});
-    });
-    return true;
-  }
-}
-
-// if helper is being run directly by mocha, skip it.
-if (exports.skip()) return;
-
 // test globals
 assert = require('assert');
 debug = require('./debug');
@@ -23,16 +10,6 @@ util = require('util');
 var child = require('child_process');
 var control = require('strong-control-channel/process');
 var dgram = require('dgram');
-
-// Assert if test does not explicitly say it passed, guards against accidental
-// exit with `0`.
-exports.pass = false;
-
-process.on('exit', function(status) {
-  if (status === 0) {
-    assert(exports.pass);
-  }
-});
 
 // Utility functions
 

--- a/test/test-mocha-tests.js
+++ b/test/test-mocha-tests.js
@@ -1,21 +1,25 @@
-var cp = require('child_process');
 var path = require('path');
+var tap = require('tap');
 
 // mocha tests assume they are run from package root, not test/
 var cwd = path.resolve(__dirname, '../');
+var mocha = require.resolve('mocha/bin/_mocha');
 var args = [
-  '--reporter', 'tap',
-  'test/chdir.js',
-  'test/debug.js',
-  'test/expander.js',
-  'test/metrics.js',
-  'test/pidfile.js',
-  'test/printf-replacer.js',
-  'test/supervisor-detach.js',
-  'test/supervisor.js',
+  mocha, '--reporter', 'tap',
 ];
 
-cp.spawn('_mocha', args, {cwd: cwd, stdio: 'inherit'})
-  .on('exit', function(code) {
-    process.exit(code);
+tap.test('mocha tests', function(t) {
+  var tests = [
+    'test/chdir.js',
+    'test/expander.js',
+    'test/metrics.js',
+    'test/pidfile.js',
+    'test/printf-replacer.js',
+    'test/supervisor-detach.js',
+    'test/supervisor.js',
+  ];
+  tests.forEach(function(test) {
+    t.spawn(process.execPath, args.concat([test]), {cwd: cwd}, test);
   });
+  t.end();
+});

--- a/test/test-run-agent-traces.js
+++ b/test/test-run-agent-traces.js
@@ -1,10 +1,8 @@
+var debug = require('./debug');
 var helper = require('./helper');
-if (helper.skip()) return;
-helper.pass = true; // Use tap, not this check.
-
 var http = require('http');
 var tap = require('tap');
-var debug = require('./debug');
+
 var run = helper.runWithControlChannel;
 
 tap.test('agent traces are forwarded via parentCtl', function(t) {
@@ -27,9 +25,10 @@ tap.test('agent traces are forwarded via parentCtl', function(t) {
         break;
     }
   });
+  // keep test alive until app exits
+  app.ref();
   app.on('exit', function(code, signal) {
     debug('supervisor exit: %s', signal || code);
-    t.end();
   });
 });
 

--- a/test/test-run-express-records.js
+++ b/test/test-run-express-records.js
@@ -1,11 +1,8 @@
-var helper = require('./helper');
-if (helper.skip()) return;
-helper.pass = true; // Use tap, not this check.
-
-var http = require('http');
-var tap = require('tap');
 var debug = require('./debug');
+var helper = require('./helper');
+var http = require('http');
 var run = helper.runWithControlChannel;
+var tap = require('tap');
 
 tap.test('express-metrics are forwarded via parentCtl', function(t) {
   t.plan(7);
@@ -30,6 +27,8 @@ tap.test('express-metrics are forwarded via parentCtl', function(t) {
         break;
     }
   });
+  // keep test alive until app exits
+  app.ref();
   app.on('exit', function(code, signal) {
     debug('supervisor exit: %s', signal || code);
     t.end();

--- a/test/test-run-trace.js
+++ b/test/test-run-trace.js
@@ -1,11 +1,8 @@
-var helper = require('./helper');
-if (helper.skip()) return;
-helper.pass = true; // Use tap, not this check.
-
-var http = require('http');
-var tap = require('tap');
 var debug = require('./debug');
+var helper = require('./helper');
+var http = require('http');
 var run = helper.runWithControlChannel;
+var tap = require('tap');
 
 tap.test('traces are forwarded via parentCtl', function(t) {
   t.plan(2);
@@ -23,6 +20,7 @@ tap.test('traces are forwarded via parentCtl', function(t) {
       }
     }
   );
+  app.ref();
   app.on('exit', function(code, signal) {
     debug('supervisor exit: %s', signal || code);
     t.end();

--- a/test/test-runctl-env.js
+++ b/test/test-runctl-env.js
@@ -2,9 +2,6 @@ var byline = require('byline');
 var child = require('child_process');
 var debug = require('debug')('runctl-test');
 var helper = require('./helper');
-
-if (helper.skip()) return;
-
 var test = require('tap').test;
 
 test('environment controls', function(t) {
@@ -13,8 +10,8 @@ test('environment controls', function(t) {
 
   // supervisor should exit with 0 after we stop it
   run.on('exit', function(code, signal) {
-    assert.equal(code, 0);
-    helper.pass = true;
+    t.equal(code, 0);
+    t.end();
   });
 
   t.test('initial', function(tt) {
@@ -67,8 +64,9 @@ test('environment controls', function(t) {
   });
 
   t.test('exit', function(tt) {
-    run.ctl(tt, 'stop');
-    tt.end();
+    run.ctl(tt, 'stop', [], function() {
+      tt.end();
+    });
   });
 });
 

--- a/test/test-runctl-heap-snapshot.js
+++ b/test/test-runctl-heap-snapshot.js
@@ -1,7 +1,5 @@
-// test sl-runctl heap dump
 var helper = require('./helper');
-
-if (helper.skip()) return;
+var tap = require('tap');
 
 var rc = helper.runCtl;
 var supervise = rc.supervise;
@@ -10,27 +8,48 @@ var failon = rc.failon;
 var waiton = rc.waiton;
 
 var APP = require.resolve('./module-app');
+var name = 'foo-' + Date.now();
 
 var run = supervise(APP);
 
-// supervisor should exit with 0 after we stop it
-run.on('exit', function(code, signal) {
-  assert.equal(code, 0);
+tap.test('runctl heap snapshot', function(t) {
+  // supervisor should exit with 0 after we stop it
+  run.on('exit', function(code, signal) {
+    t.equal(code, 0);
+    t.end();
+  });
+
+  t.doesNotThrow(function() {
+    cd(path.dirname(APP));
+  });
+
+  t.doesNotThrow(function() {
+    waiton('', /worker count: 0/);
+  });
+  t.doesNotThrow(function() {
+    expect('set-size 1');
+  });
+  t.doesNotThrow(function() {
+    waiton('status', /worker count: 1/);
+  });
+  t.doesNotThrow(function() {
+    expect('status', /worker id 1:/);
+  });
+
+  t.doesNotThrow(function() {
+    expect('heap-snapshot 0', /node\.0.*\.heapsnapshot/);
+  });
+  t.doesNotThrow(function() {
+    expect('heap-snapshot 1', /node\.1.*\.heapsnapshot/);
+  });
+
+  t.doesNotThrow(function() {
+    expect('heap-snapshot 1 ' + name, /foo.*\.heapsnapshot/);
+  });
+  t.doesNotThrow(function() {
+    failon('heap-snapshot 1 /does/not/exist', /ENOENT/);
+  });
+  t.doesNotThrow(function() {
+    expect('stop');
+  });
 });
-
-
-cd(path.dirname(APP));
-
-waiton('', /worker count: 0/);
-expect('set-size 1');
-waiton('status', /worker count: 1/);
-expect('status', /worker id 1:/);
-
-expect('heap-snapshot 0', /node\.0.*\.heapsnapshot/);
-expect('heap-snapshot 1', /node\.1.*\.heapsnapshot/);
-var name = 'foo-' + Date.now();
-expect('heap-snapshot 1 ' + name, /foo.*\.heapsnapshot/);
-failon('heap-snapshot 1 /does/not/exist', /ENOENT/);
-expect('stop');
-
-helper.pass = true;

--- a/test/test-runctl-ls.js
+++ b/test/test-runctl-ls.js
@@ -1,6 +1,5 @@
 var helper = require('./helper');
-
-if (helper.skip()) return;
+var tap = require('tap');
 
 var rc = helper.runCtl;
 var supervise = rc.supervise;
@@ -11,16 +10,27 @@ var app = require.resolve('./module-app');
 
 var run = supervise(app);
 
-// supervisor should exit with 0 after we stop it
-run.on('exit', function(code, signal) {
-  assert.equal(code, 0);
+tap.test('runctl ls', function(t) {
+  // supervisor should exit with 0 after we stop it
+  run.on('exit', function(code, signal) {
+    t.equal(code, 0);
+    t.end();
+  });
+
+  t.doesNotThrow(function() {
+    cd(path.dirname(app));
+  });
+
+  t.doesNotThrow(function() {
+    waiton('', /worker count: 0/);
+  });
+  t.doesNotThrow(function() {
+    expect('ls', /module-app@0.0.0/);
+  });
+  t.doesNotThrow(function() {
+    expect('ls 1', /module-app@0.0.0/);
+  });
+  t.doesNotThrow(function() {
+    expect('stop');
+  });
 });
-
-cd(path.dirname(app));
-
-waiton('', /worker count: 0/);
-expect('ls', /module-app@0.0.0/);
-expect('ls 1', /module-app@0.0.0/);
-expect('stop');
-
-helper.pass = true;

--- a/test/test-runctl-patch.js
+++ b/test/test-runctl-patch.js
@@ -1,6 +1,5 @@
 var helper = require('./helper');
-
-if (helper.skip()) return;
+var tap = require('tap');
 
 var rc = helper.runCtl;
 var expect = rc.expect;
@@ -12,19 +11,27 @@ var app = require.resolve('./module-app');
 
 var run = supervise(app);
 
-// supervisor should exit with 0 after we stop it
-run.on('exit', function(code, signal) {
-  assert.equal(code, 0);
-});
+tap.test('runctl patch', function(t) {
+  // supervisor should exit with 0 after we stop it
+  run.on('exit', function(code, signal) {
+    t.equal(code, 0);
+    t.end();
+  });
 
-cd(path.dirname(app));
+  t.doesNotThrow(function() {
+    cd(path.dirname(app));
+  });
 
-waiton('', /worker count: 0/);
+  t.doesNotThrow(function() {
+    waiton('', /worker count: 0/);
+  });
 
 // Just test the patch command communication, particularly what happens when
 // `--metrics` was not provided as an option to `slc run` (the actual behaviour
 // of applied patches is tested in strong-agent).
-fs.writeFileSync('_patch.json', '{"no-such-file-anywhere-i-hope":[]}');
+  t.doesNotThrow(function() {
+    fs.writeFileSync('_patch.json', '{"no-such-file-anywhere-i-hope":[]}');
+  });
 
 /*
 XXX(sam) Metrics can't be disabled ATM, not if you have a parent process, so
@@ -33,6 +40,7 @@ this will require a different way of spawning the child process to trigger.
 failon('patch 0 _patch.json', /not configured to report metrics/);
 */
 
-expect('stop');
-
-helper.pass = true;
+  t.doesNotThrow(function() {
+    expect('stop');
+  });
+});


### PR DESCRIPTION
Some of the breaking change were:
 * non-tap tests reporting as failures
 * tap output being polluted by expect/waiton output
 * event loop no longer being kept alive by tap itself

The largest changes in the PR are converting the sync tests to async by wrapping each blocking step in a `t.doesNotThrow()` which let me get away with _not_ rewriting `expect`, `waiton`, `failon`, etc. as async functions.

Now to see if Jenkins can handle nested TAP...