### PR TITLE
test: improve runctl-clusterctl robustness

### DIFF
--- a/test/test-runctl-clusterctl.js
+++ b/test/test-runctl-clusterctl.js
@@ -29,74 +29,77 @@ tap.test('runctl via clusterctl', function(t) {
 
   t.doesNotThrow(function() {
     cd(path.dirname(APP));
-  });
+  }, 'cd');
 
   t.doesNotThrow(function() {
     waiton('', /worker count: 0/);
-  });
+  }, 'status');
 
   t.doesNotThrow(function() {
     expect('set-size 1');
-  });
+  }, 'set-size');
 
   t.doesNotThrow(function() {
     waiton('status', /worker count: 1/);
-  });
+  }, 'status count 1');
 
   t.doesNotThrow(function() {
     expect('status', /worker id 1:/);
-  });
+  }, 'status worker id 1');
 
   t.doesNotThrow(function() {
     expect('set-size 2');
-  });
+  }, 'set-size 2');
 
   t.doesNotThrow(function() {
     waiton('status', /worker count: 2/);
-  });
+  }, 'status count 2');
 
   t.doesNotThrow(function() {
     expect('status', /worker id 2:/);
-  });
+  }, 'status worker id 1');
 
   t.doesNotThrow(function() {
     expect('restart');
-  });
+  }, 'restart');
 
   t.doesNotThrow(function() {
     waiton('status', /worker id 4:/);
-  });
+  }, 'status worker id 4');
 
   t.doesNotThrow(function() {
     expect('status', /worker count: 2/);
-  });
+  }, 'status worker count 2');
 
   t.doesNotThrow(function() {
     expect('fork', /workerID: 5/);
-  });
+  }, 'fork worker id 5');
 
-  t.doesNotThrow(function() {
-    waiton('status', /worker count: 3/);
-  });
+  /* XXX(sam) racy... whether we see the 3 or not is just a matter of
+   * luck
+   * t.doesNotThrow(function() {
+   * waiton('status', /worker count: 3/);
+   * }, 'status worker count 3');
+   */
 
   // cluster control kills off the extra worker
   t.doesNotThrow(function() {
     waiton('status', /worker count: 2/);
-  });
+  }, 'status worker count 2');
 
   t.doesNotThrow(function() {
     expect('disconnect');
-  });
+  }, 'disconnect');
 
   t.doesNotThrow(function() {
-    waiton('status', /worker id 6:/);
-  });
+    waiton('status', /worker count: 2/);
+  }, 'status worker count 2');
 
   t.doesNotThrow(function() {
-    expect('status', /worker count: 2/);
-  });
+    expect('status', /worker id 6:/);
+  }, 'status worker id 6');
 
   t.doesNotThrow(function() {
     expect('stop');
-  });
+  }, 'stop');
 });


### PR DESCRIPTION
Tests had no labels, making it very difficult to see which one was
failing.

Some tests, such as wanting to see an increased count after a fork, were
inherently racy, whether the status request comes before the controller
kills the extra unwanted worker is a matter of timing. Also, a test that
waited for the first of two workers to be replaced, and then asserted
that both workers were already replaced was racy.

I could get intermittent failures before these changes, but tests seem
much more robust now.