### PR TITLE
tracer: initialize tracer before agent

### DIFF
--- a/bin/sl-run.js
+++ b/bin/sl-run.js
@@ -12,6 +12,11 @@ var assert = require('assert');
 var config = require('../lib/config'); // May exit, depending on argv
 var log = config.logger;
 
+var tracer = require('../lib/tracer');
+if (config.enableTracing) {
+  tracer(tracer.tracerOptions());
+}
+
 var agent = require('../lib/agent');
 var agentOptions = {
   quiet: config.isWorker, // Quiet in worker, to avoid repeated log messages
@@ -53,11 +58,6 @@ switch (config.profile) {
 
 if ((config.clustered && config.isMaster) || config.detach) {
   return config.start();
-}
-
-if (config.enableTracing) {
-  var tracer = require('../lib/tracer');
-  tracer(tracer.tracerOptions());
 }
 
 config.sendMetrics();

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var agent = require('./agent');
 
 exports = module.exports = tracer;
@@ -15,8 +17,16 @@ function tracer(options) {
 function tracerOptions() {
   return {
     archiveInterval: 20000,
-    accountKey: agent().config.appName,
+    accountKey: getAppName(),
     useHttp: false,
     lrtime: agent().internal.lrtime,
   };
+}
+
+function getAppName() {
+  try {
+    return require('package.json').name;
+  } catch (er) {
+    return 'no_name';
+  }
 }


### PR DESCRIPTION
The tracer needs to monkey-patch require to rewrite all required js code
to insert instumentation. If its initialized after strong-agent, any
code that strong-agent requires won't be instrumented.

connected to strongloop-internal/scrum-nodeops#487