### PR TITLE
runctl: allow cluster size to be set to CPUs

### DIFF
--- a/bin/sl-runctl.js
+++ b/bin/sl-runctl.js
@@ -124,7 +124,7 @@ function displayStatusResponse(rsp) {
 
 function requestSetSize() {
   request.cmd = 'set-size';
-  request.size = parseInt(requiredArg(), 10);
+  request.size = requiredArg();
 }
 
 function requestStop() {

--- a/lib/runctl.js
+++ b/lib/runctl.js
@@ -7,6 +7,7 @@ var debug = require('./debug')('runctl');
 var fs = require('fs');
 var master = require('strong-cluster-control');
 var npmls = require('strong-npm-ls');
+var os = require('os');
 var targetctl = require('./targetctl');
 var util = require('util');
 
@@ -138,6 +139,10 @@ function onRequest(req, callback) {
     });
   } else if (cmd === 'set-size') {
     try {
+      if (/cpu/i.test(req.size))
+        req.size = os.cpus().length;
+      else
+        req.size = +req.size;
       master.setSize(req.size);
     } catch (er) {
       rsp.error = er.message;

--- a/test/test-runctl-clusterctl.js
+++ b/test/test-runctl-clusterctl.js
@@ -1,4 +1,5 @@
 var helper = require('./helper');
+var os = require('os');
 var tap = require('tap');
 
 var rc = helper.runCtl;
@@ -7,6 +8,7 @@ var expect = rc.expect;
 var waiton = rc.waiton;
 
 var APP = require.resolve('./module-app');
+var CPUS = os.cpus().length;
 
 process.env.SL_RUN_SKIP_IPCCTL =
   'We have to disable ipcctl in master because its parent is a bunch of' +
@@ -75,12 +77,12 @@ tap.test('runctl via clusterctl', function(t) {
     expect('fork', /workerID: 5/);
   }, 'fork worker id 5');
 
-  /* XXX(sam) racy... whether we see the 3 or not is just a matter of
-   * luck
-   * t.doesNotThrow(function() {
-   * waiton('status', /worker count: 3/);
-   * }, 'status worker count 3');
-   */
+  // XXX(sam) racy... whether we see the 3 or not is just a matter of
+  // luck
+  // t.doesNotThrow(function() {
+  // waiton('status', /worker count: 3/);
+  // }, 'status worker count 3');
+  //
 
   // cluster control kills off the extra worker
   t.doesNotThrow(function() {
@@ -98,6 +100,22 @@ tap.test('runctl via clusterctl', function(t) {
   t.doesNotThrow(function() {
     expect('status', /worker id 6:/);
   }, 'status worker id 6');
+
+  t.doesNotThrow(function() {
+    expect('set-size 0');
+  }, 'set-size 0');
+
+  t.doesNotThrow(function() {
+    waiton('status', RegExp('worker count: 0'));
+  }, 'status count 0');
+
+  t.doesNotThrow(function() {
+    expect('set-size CPUs');
+  }, 'set-size CPUs');
+
+  t.doesNotThrow(function() {
+    waiton('status', RegExp('worker count: ' + CPUS));
+  }, 'status count CPUs');
 
   t.doesNotThrow(function() {
     expect('stop');


### PR DESCRIPTION
Command line and environment variable parsing supported a cluster size
of "cpus", but the set-size command did not, now it does.