### PR TITLE
trace-object: emit record as string, not object

### DIFF
--- a/lib/watcher/trace-object.js
+++ b/lib/watcher/trace-object.js
@@ -20,7 +20,7 @@ exports.worker = function(handle) {
   tracer().on('trace:object', function(record) {
     handle.send({
       cmd: 'trace:object',
-      record: record,
+      record: JSON.stringify(record),
     });
   });
 };

--- a/test/test-run-trace.js
+++ b/test/test-run-trace.js
@@ -13,8 +13,9 @@ tap.test('traces are forwarded via parentCtl', function(t) {
       debug('received: cmd %s: %j', data.cmd, data);
       switch (data.cmd) {
         case 'trace:object':
-          t.ok(!!data.record.version, 'Record version should exist');
-          t.ok(!!data.record.packet.metadata, 'Record data should exist');
+          var record = JSON.parse(data.record);
+          t.ok(!!record.version, 'Record version should exist');
+          t.ok(!!record.packet.metadata, 'Record metadata should exist');
           app.kill();
           break;
       }
@@ -54,8 +55,9 @@ tap.test('traces can be turned on', function(t) {
         break;
       case 'trace:object':
         t.assert(tracingEnabled);
-        t.ok(!!data.record.version, 'Record version should exist');
-        t.ok(!!data.record.packet.metadata, 'Record data should exist');
+        var record = JSON.parse(data.record);
+        t.ok(!!record.version, 'Record version should exist');
+        t.ok(!!record.packet.metadata, 'Record metadata should exist');
         break;
     }
   }
@@ -94,8 +96,9 @@ tap.test('traces can be turned off', function(t) {
         break;
       case 'trace:object':
         t.assert(tracingEnabled);
-        t.ok(!!data.record.version, 'Record version should exist');
-        t.ok(!!data.record.packet.metadata, 'Record data should exist');
+        var record = JSON.parse(data.record);
+        t.ok(!!record.version, 'Record version should exist');
+        t.ok(!!record.packet.metadata, 'Record metadata should exist');
         break;
     }
   }

--- a/test/test-watch-trace-object.js
+++ b/test/test-watch-trace-object.js
@@ -40,8 +40,10 @@ tap.test('trace-object', function(t) {
       debug('trace:object: %s', debug.json(msg));
       tt.equal(type, 'send');
       tt.equal(msg.cmd, 'trace:object');
-      tt.assert(msg.record.version);
-      tt.assert(msg.record.packet);
+      tt.equal(typeof msg.record, 'string');
+      var record = JSON.parse(msg.record);
+      tt.assert(record.version);
+      tt.assert(record.packet);
       tt.end();
     }
   });


### PR DESCRIPTION
Stringify the record object before forwarding it.  Avoids a number of
deserialize/reserialize steps down the chain.

There is still some overhead because the implicit JSON.stringify() and
JSON.parse() calls around process.send() escape and unescape the string
but that is cheaper than repeatedly (de)serializing the object graph.

R=@sam-github