### PR TITLE
Override hostname returned in trace packet

### DIFF
--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -19,6 +19,7 @@ var options = {
   useHttp: false,
   lrtime: lrtime,
   blacklist: ['*node_modules/strong-agent/*'],
+  traceId: process.env.STRONGLOOP_TRACES_ID, // returned as hostname in trace
 };
 
 function tracer() {


### PR DESCRIPTION
* Use STRONGLOOP_HOSTNAME_OVERRIDE env to override

Connect to strongloop-internal/scrum-nodeops#718