### PR TITLE
make status message as complete as started message

### DIFF
--- a/lib/runctl.js
+++ b/lib/runctl.js
@@ -16,6 +16,13 @@ var processChannel = require('strong-control-channel/process').attach;
 exports.start = start;
 exports.onRequest = onRequest; // For testing
 
+// sent on startup and with every status message
+var osVersion = {
+  platform: os.platform(),
+  arch: os.arch(),
+  release: os.release()
+};
+
 var ctlChannel = {
   notify: function notify(req) {
     debug('notify: ipcctl? %j %s', !!ipcctl, debug.json(req));
@@ -55,11 +62,7 @@ if (cluster.isMaster) {
       appName: agent().config.appName,
       agentVersion: agentVersion,
       nodeVersion: process.version,
-      osVersion: {
-        platform: os.platform(),
-        arch: os.arch(),
-        release: os.release()
-      },
+      osVersion: osVersion,
       setSize: master.size,
     });
 
@@ -289,5 +292,7 @@ function clusterStatus() {
   mStatus.master.pst = mStatus.master.pst || mStatus.master.startTime;
   mStatus.appName = agent().config.appName;
   mStatus.agentVersion = agentVersion;
+  mStatus.nodeVersion = process.version;
+  mStatus.osVersion = osVersion;
   return mStatus;
 }

--- a/test/test-run-process-control.js
+++ b/test/test-run-process-control.js
@@ -1,6 +1,7 @@
 var control = require('strong-control-channel/process');
 var cp = require('child_process');
 var debug = require('./debug');
+var os = require('os');
 var tap = require('tap');
 
 var options = {stdio: [0, 1, 2, 'ipc']};
@@ -22,6 +23,12 @@ tap.test('status', function(t) {
     t.equal(rsp.workers.length, 0, 'no workers');
     t.equal(rsp.appName, 'yes-app', 'appName');
     t.assert(/^\d+\.\d+\.\d+/.test(rsp.agentVersion), 'agentVersion');
+    t.match(rsp.osVersion, {
+      platform: os.platform(),
+      arch: os.arch(),
+      release: os.release(),
+    }, 'osVersion');
+    t.match(rsp.nodeVersion, process.version, 'nodeVersion');
     t.end();
   });
 });


### PR DESCRIPTION
Allows a controller to poll for the current status of a running master
and get a relatively complete picture even though it wasn't there to
receieve the original 'started' message. A concrete example of this is
when supervisor is running in a docker container and the PM instance
that spawned it was restarted.

Needed by strongloop/strong-pm#242