### PR TITLE
runctl: handle signal-type messages

### DIFF
--- a/lib/runctl.js
+++ b/lib/runctl.js
@@ -4,6 +4,7 @@ var agentVersion = require('strong-agent/package.json').version;
 var async = require('async');
 var cluster = require('cluster');
 var debug = require('./debug')('runctl');
+var EventEmitter = require('events').EventEmitter;
 var fs = require('fs');
 var master = require('strong-cluster-control');
 var npmls = require('strong-npm-ls');
@@ -15,6 +16,11 @@ var processChannel = require('strong-control-channel/process').attach;
 
 exports.start = start;
 exports.onRequest = onRequest; // For testing
+
+// Return the number of event listeners.
+var listenerCount = EventEmitter.listenerCount || function(emitter, event) {
+  return emitter.listeners(event).length;
+};
 
 // sent on startup and with every status message
 var osVersion = {
@@ -227,6 +233,18 @@ function onRequest(req, callback) {
       master.restart();
     } catch (er) {
       rsp.error = er.message;
+    }
+
+  } else if (cmd === 'signal') {
+    if (req.pid !== process.pid) {
+     // Do nothing
+    } else if (listenerCount(process, req.signame) > 0) {
+      // If there are any listeners for this signal, emit it on the
+      // process object.
+      process.emit(req.signame);
+    } else {
+      // If there are no listeners, use the default action.
+      process.kill(process.pid, req.signame);
     }
 
   } else {


### PR DESCRIPTION
No tests are added; however this path will be stressed by strong-runner
once it starts sending this type of message.

@sam-github 

connect to strongloop-internal/scrum-nodeops#455