### PR TITLE
fix regression in PWD/CWD handling caused by #142

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -9,7 +9,7 @@
 var options = require('./options').parse(process.argv);
 
 var Logger = require('./logger');
-var chdir = require('./chdir');
+var chdir = require('./chdir'); // side effect: ensures correct process.env.PWD
 var cluster = require('cluster');
 var control = require('strong-cluster-control');
 var debug = require('./debug')('config');
@@ -95,7 +95,7 @@ if (options.enableTracing) process.env.STRONGLOOP_TRACING = 1;
 // Communicate detach option to the master using config.
 config.detach = options.detach;
 
-var app = startCmd(process.cwd(), process.argv);
+var app = startCmd(process.env.PWD, process.argv);
 if (app.error) {
   console.error('Invalid app (%s), try `%s --help`.\n',
                 app.error.message || app.error, options.NAME);

--- a/lib/start-command.js
+++ b/lib/start-command.js
@@ -17,6 +17,7 @@ exports.fromStart = fromStart;
 // of the script is also resolving what directory the script should be run from.
 function resolveArgs(cwd, argv) {
   var script = argv[2] || '.';
+  debug('resolving CWD: %j, path: %j', cwd, script);
   var app = resolvePath(cwd, script);
   var stat = app.stat;
   if (app.error) {


### PR DESCRIPTION
By calling `process.cwd()` we are getting a fully resolved path, which
completely undoes all the effort to run within a CWD that is a symlink.

process.env.PWD is ensured to always be set because lib/chdir.js sets
it if it isn't already set.

@piscisaureus this was the cause of strong-runner tests failing for me on master - with this change, they all pass for me.

R= @piscisaureus || @kraman 