### PR TITLE
run: ws endpoint now has default

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -184,7 +184,11 @@ exports.parse = function parse(argv) {
   }
 
   if (options.channel && url.parse(options.channel).protocol) {
-    options.channel = defaults(options.channel, {}, {protocol: 'ws'});
+    options.channel = defaults(options.channel, {
+      path: 'supervisor-control'
+    }, {
+      protocol: 'ws'
+    });
     process.env.STRONGLOOP_CONTROL = options.channel;
     options.channel = false;
   } else {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "strong-npm-ls": "^1.0.0",
     "strong-statsd": "^2.0.0",
     "strong-trace": "^1.2.0",
-    "strong-url-defaults": "^1.1.0",
+    "strong-url-defaults": "^1.2.0",
     "strongloop-license": "^1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The default is supervisor-control, as used by strong-central and
strong-pm.