### PR TITLE
fix accidental heapdump generation on log re-open

### DIFF
--- a/lib/targetctl.js
+++ b/lib/targetctl.js
@@ -9,6 +9,8 @@ var capabilities = require('./capabilities');
 var heapdump = null;
 var async = require('async');
 
+// override any other options since some of them will break us
+process.env.NODE_HEAPDUMP_OPTIONS = 'nosignal';
 try {
   heapdump = require('heapdump');
 } catch (e) {


### PR DESCRIPTION
The heapdump module by default triggers on SIGUSR2, but we use that
signal to re-open our log files. The result is we generate a heapdump
every time the logs are rotated.

Connect to #150