### PR TITLE
runctl: fork ppid should not depend on msg order

### DIFF
--- a/lib/runctl.js
+++ b/lib/runctl.js
@@ -78,9 +78,6 @@ if (cluster.isMaster) {
       setSize: master.size,
     });
 
-    // Store pid for later use in fork messages
-    master.pid = process.pid;
-
     // Status notifications usually come after every fork and exit, but if there
     // are no forks, we still want at least one status notification sent. Note
     // that size may be undefined, which isn't > or < than 1.
@@ -108,7 +105,7 @@ if (cluster.isMaster) {
       cmd: 'fork',
       wid: worker.id,
       pid: worker.process.pid,
-      ppid: master.pid,
+      ppid: process.pid,
       pst: worker.startTime,
     });
     notifyStatus();


### PR DESCRIPTION
If fork event occured before notifyStarted(), the fork message would not
have a ppid, and the process would not be saved in the mesh models.

@kraman You added master.pid in #134, but it doesn't appear to be necessary, and looks to be the cause of https://github.com/strongloop-internal/scrum-nodeops/issues/811. I think the unexpected ordering of events only happens when central is remote from supervisor.

connected to strongloop-internal/scrum-nodeops#811