### PR TITLE
Use modern-syslog, not our fork of node-syslog

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
   },
   "optionalDependencies": {
     "heapdump": "^0.3.5",
-    "strong-fork-syslog": "^1.2.1"
+    "modern-syslog": "^1.x"
   }
 }


### PR DESCRIPTION
I did a quick test, the tests pass, and I did a `slc run --syslog --cluster=1` of the express example app, and the output was indeed syslogged.

connected to strongloop-internal/scrum-nodeops#893