### PR TITLE
runctl: re-chdir to PWD on restart

### DIFF
--- a/lib/runctl.js
+++ b/lib/runctl.js
@@ -192,6 +192,13 @@ function onRequest(req, callback) {
 
   } else if (cmd === 'restart') {
     try {
+      process.chdir(process.env.PWD);
+    } catch (er) {
+      // Ignore, things will probably go poorly, but we don't want the master to
+      // die even if the working directory becomes inaccessible, or the PWD,
+      // probably a current link, becomes invalid.
+    }
+    try {
       master.restart();
     } catch (er) {
       rsp.error = er.message;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "supervisor and monitor for node.js applications",
   "author": "Sam Roberts <sam@strongloop.com>",
   "license": "Artistic-2.0 OR LicenseRef-LICENSE.md",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "main": "index.js",
   "keywords": [
     "agent",


### PR DESCRIPTION
The PWD might be the "current" symlink in which case chdiring will bring
the app up in the currently up-to-date app location.

connected to strongloop-internal/scrum-nodeops#455