### PR TITLE
Control channel for strong-debugger

### DIFF
--- a/bin/sl-runctl.js
+++ b/bin/sl-runctl.js
@@ -94,6 +94,9 @@ var commands = {
   'env-get': requestEnvGet,
   'env-set': requestEnvSet,
   'env-unset': requestEnvUnSet,
+  'dbg-start': requestDebuggerStart,
+  'dbg-stop': requestDebuggerStop,
+  'dbg-status': requestDebuggerStatus,
 };
 
 var action = commands[command] || invalidCommand;
@@ -101,7 +104,7 @@ var action = commands[command] || invalidCommand;
 action();
 
 function invalidCommand() {
-  error('Invalid command `%s`, try `%s --help`.', $0);
+  error('Invalid command `%s`, try `%s --help`.', command, $0);
 }
 
 function requestStatus() {
@@ -265,6 +268,37 @@ function requestEnvSet() {
 function requestEnvUnSet() {
   request.cmd = 'env-unset';
   request.env = argv.slice(optind++);
+}
+
+function requestDebuggerStart() {
+  request.cmd = 'dbg-start';
+  request.target = requiredArg();
+
+  display = function debuggerStarted(rsp) {
+    if (rsp.error || !rsp.port) {
+      console.error('Unable to start the debugger:', rsp.error || 'unknown');
+    } else {
+      console.log('Debugger listening on port %s', rsp.port);
+    }
+  };
+}
+
+function requestDebuggerStop() {
+  request.cmd = 'dbg-stop';
+  request.target = requiredArg();
+}
+
+function requestDebuggerStatus() {
+  request.cmd = 'dbg-status';
+  request.target = requiredArg();
+
+  display = function printDebuggerStatus(rsp) {
+    if (rsp.status.running) {
+      console.log('Debugger listening on port %s', rsp.status.port);
+    } else {
+      console.log('Debugger is disabled.');
+    }
+  };
 }
 
 debug('addr: %j, request: %j', ADDR, request);

--- a/bin/sl-runctl.txt
+++ b/bin/sl-runctl.txt
@@ -43,5 +43,14 @@ Commands:
   env-unset <KEYS...>        Unset environment variables in master and workers.
                              Changes are live without process restart.
 
+  dbg-start <ID>             Enable DevTools Debugger backend in the target
+                             worker.
+
+  dbg-stop <ID>              Disable DevTools Debugger backend in the target
+                             worker.
+
+  dbg-status <ID>            Get the status of DevTools Debugger in the target
+                             worker.
+
 Commands specific to a worker ID accept either a process ID or cluster worker
 ID, and use an ID of `0` to mean the cluster master.

--- a/lib/targetctl.js
+++ b/lib/targetctl.js
@@ -9,6 +9,7 @@ var capabilities = require('./capabilities');
 var heapdump = null;
 var async = require('async');
 var strongDebugger = require('strong-debugger');
+var extend = require('util')._extend;
 
 // override any other options since some of them will break us
 process.env.NODE_HEAPDUMP_OPTIONS = 'nosignal';
@@ -229,6 +230,7 @@ function startDebugger(req, rsp, callback) {
   strongDebugger.start(0, function(err, port) {
     rsp.error = err && err.message;
     rsp.port = port;
+    addDebuggerStatusNotification(rsp);
     callback(rsp);
   });
 }
@@ -240,8 +242,19 @@ function stopDebugger(req, rsp, callback) {
   }
 
   strongDebugger.stop(function() {
+    addDebuggerStatusNotification(rsp);
     callback(rsp);
   });
+}
+
+function addDebuggerStatusNotification(rsp) {
+  var worker = getWorkerInfo();
+  rsp.notify = {
+    wid: worker.id,
+    pid: worker.pid,
+    cmd: 'debugger-status',
+  };
+  extend(rsp.notify, strongDebugger.status());
 }
 
 function debuggerStatus(req, rsp, callback) {

--- a/lib/targetctl.js
+++ b/lib/targetctl.js
@@ -8,6 +8,7 @@ var fs = require('fs');
 var capabilities = require('./capabilities');
 var heapdump = null;
 var async = require('async');
+var strongDebugger = require('strong-debugger');
 
 // override any other options since some of them will break us
 process.env.NODE_HEAPDUMP_OPTIONS = 'nosignal';
@@ -196,6 +197,15 @@ function onRequest(req, callback) {
         }
         break;
 
+      case 'dbg-start':
+        return startDebugger(req, rsp, callback);
+
+      case 'dbg-stop':
+        return stopDebugger(req, rsp, callback);
+
+      case 'dbg-status':
+        return debuggerStatus(req, rsp, callback);
+
       // Unsupported
       default:
         rsp.error = 'unsupported';
@@ -207,5 +217,39 @@ function onRequest(req, callback) {
 
   debug('request %s => response %s', debug.json(req), debug.json(rsp));
 
+  callback(rsp);
+}
+
+function startDebugger(req, rsp, callback) {
+  if (cluster.isMaster) {
+    rsp.error = 'Cannot debug the supervisor process itself.';
+    return callback(rsp);
+  }
+
+  strongDebugger.start(0, function(err, port) {
+    rsp.error = err && err.message;
+    rsp.port = port;
+    callback(rsp);
+  });
+}
+
+function stopDebugger(req, rsp, callback) {
+  if (cluster.isMaster) {
+    rsp.error = 'Cannot debug the supervisor process itself.';
+    return callback(rsp);
+  }
+
+  strongDebugger.stop(function() {
+    callback(rsp);
+  });
+}
+
+function debuggerStatus(req, rsp, callback) {
+  if (cluster.isMaster) {
+    rsp.error = 'Cannot debug the supervisor process itself.';
+    return callback(rsp);
+  }
+
+  rsp.status = strongDebugger.status();
   callback(rsp);
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "strong-agent": "^2.0.0",
     "strong-cluster-control": "^2.0.0",
     "strong-control-channel": "^2.0.0",
+    "strong-debugger": "^1.0.0",
     "strong-log-transformer": "^1.0.0",
     "strong-npm-ls": "^1.0.0",
     "strong-statsd": "^2.0.0",

--- a/test/test-ipcctl-notifications.js
+++ b/test/test-ipcctl-notifications.js
@@ -140,7 +140,7 @@ test('start cpu profiling', function(t) {
   });
 
   ctl.request({cmd: 'start-cpu-profiling', target: 2}, once(t, function(rsp) {
-    t.assert(!rsp.error);
+    t.ifError(rsp.error);
   }));
 });
 
@@ -158,7 +158,7 @@ test('stop cpu profling', function(t) {
 
   var req = {cmd: 'stop-cpu-profiling', target: 2};
   ctl.request(req, once(t, function(rsp) {
-    t.assert(!rsp.error);
+    t.ifError(rsp.error);
     t.assert(hitCount(rsp.profile) > 1);
   }));
 });
@@ -173,7 +173,7 @@ test('start cpu profiling watchdog', skipUnlessWatchdog || function(t) {
 
   var options = {cmd: 'start-cpu-profiling', target: 2, timeout: 1};
   ctl.request(options, once(t, function(rsp) {
-    t.assert(!rsp.error);
+    t.ifError(rsp.error);
   }));
 });
 
@@ -191,7 +191,7 @@ test('stop cpu profiling watchdog', skipUnlessWatchdog || function(t) {
 
   var req = {cmd: 'stop-cpu-profiling', target: 2};
   ctl.request(req, once(t, function(rsp) {
-    t.assert(!rsp.error);
+    t.ifError(rsp.error);
     t.assert(hitCount(rsp.profile) >= 1);
   }));
 });
@@ -204,7 +204,7 @@ test('start object tracking', skipIfNoLicense, function(t) {
   });
 
   ctl.request({cmd: 'start-tracking-objects', target: 2}, once(t, function(rsp) {
-    t.assert(!rsp.error);
+    t.ifError(rsp.error);
   }));
 });
 
@@ -216,7 +216,7 @@ test('stop object tracking', skipIfNoLicense, function(t) {
   });
 
   ctl.request({cmd: 'stop-tracking-objects', target: 2}, once(t, function(rsp) {
-    t.assert(!rsp.error);
+    t.ifError(rsp.error);
   }));
 });
 
@@ -229,7 +229,7 @@ test('heap snapshot', function(t) {
 
   var req = {cmd: 'heap-snapshot', target: 2};
   ctl.request(req, once(t, function(rsp) {
-    t.assert(!rsp.error);
+    t.ifError(rsp.error);
   }));
 });
 

--- a/test/test-ipcctl-notifications.js
+++ b/test/test-ipcctl-notifications.js
@@ -233,6 +233,35 @@ test('heap snapshot', function(t) {
   }));
 });
 
+test('start debugger', function(t) {
+  t.plan(5);
+  ee.once('debugger-status', function(n) {
+    t.equal(n.wid, 2, 'Worker ID should be present');
+    t.assert(n.running, 'Debugger is running');
+    t.assert(n.port > 0, 'Debugger port is reported');
+  });
+
+  var req = {cmd: 'dbg-start', target: 2};
+  ctl.request(req, once(t, function(rsp) {
+    t.ifError(rsp.error);
+  }));
+});
+
+test('stop debugger', function(t) {
+  t.plan(5);
+  ee.once('debugger-status', function(n) {
+    t.equal(n.wid, 2, 'Worker ID should be present');
+    t.notOk(n.running, 'Debugger is stopped');
+    t.equal(''+n.port, ''+null, 'Debugger port is null');
+  });
+
+  var req = {cmd: 'dbg-stop', target: 2};
+  ctl.request(req, once(t, function(rsp) {
+    t.ifError(rsp.error);
+  }));
+});
+
+
 test('disconnect', function(t) {
   helper.pass = true;
   run.on('exit', function(status) {

--- a/test/test-runctl-dbg.js
+++ b/test/test-runctl-dbg.js
@@ -1,0 +1,201 @@
+var fs = require('fs');
+var byline = require('byline');
+var child = require('child_process');
+var debug = require('debug')('runctl-test');
+var helper = require('./helper');
+var client = require('strong-control-channel/client');
+var path = require('path');
+var test = require('tap').test;
+var net = require('net');
+
+test('debugger controls', function(t) {
+  var app = path.resolve(__dirname, 'module-app');
+  var run = supervise(app);
+
+  // supervisor should exit with 0 after we stop it
+  run.on('exit', function(code, signal) {
+    t.equal(code, 0);
+    t.end();
+  });
+
+  t.test('wait for app start', function(tt) {
+    run.says(tt, /^argv/);
+  });
+
+  t.test('query initial status', function(tt) {
+    run.ctl(tt, 'dbg-status', 1, function(err, stdout, stderr) {
+      tt.ifError(err, 'dbg-status should not fail');
+      tt.match(stdout, 'Debugger is disabled.');
+      tt.end();
+    });
+  });
+
+  var port;
+  t.test('send dbg-start', function(tt) {
+    var LISTENING_PATTERN = /Debugger listening on port (\d+)/;
+    run.ctl(tt, 'dbg-start', 1, function(err, stdout, stderr) {
+      tt.ifError(err, 'dbg-start should not fail');
+      tt.match(stdout, LISTENING_PATTERN, 'stdout should include port');
+      var m = stdout.match(LISTENING_PATTERN);
+      port = m && +m[1];
+      tt.end();
+    });
+  });
+
+  t.test('query status when started', function(tt) {
+    run.ctl(tt, 'dbg-status', 1, function(err, stdout, stderr) {
+      tt.ifError(err, 'dbg-status should not fail');
+      tt.match(stdout, 'Debugger listening on port ' + port);
+      tt.end();
+    });
+  });
+
+  t.test('connect to the debugger when started', function(tt) {
+    if (!port) {
+      tt.fail('this test requires a successfull dbg-start');
+      return tt.end();
+    }
+
+    var conn = net.connect(port);
+    conn.once('error', function(err) {
+      tt.threw(err);
+    });
+    conn.once('connect', function() {
+      tt.pass('can connect to the debugger');
+      conn.end();
+      tt.end();
+    });
+  });
+
+  t.test('stop', function(tt) {
+    run.ctl(tt, 'dbg-stop', 1, function(err, stdout, stderr) {
+      tt.ifError(err, 'dbg-stop should not fail');
+      tt.end();
+    });
+  });
+
+  t.test('query status when stopped', function(tt) {
+    run.ctl(tt, 'dbg-status', 1, function(err, stdout, stderr) {
+      tt.ifError(err, 'dbg-status should not fail');
+      tt.match(stdout, 'Debugger is disabled.');
+      tt.end();
+    });
+  });
+
+  t.test('connect to the debugger when stopped', function(tt) {
+    if (!port) {
+      tt.fail('this test requires a successfull dbg-start');
+      return tt.end();
+    }
+
+    var conn = net.connect(port);
+    conn.once('error', function(err) {
+      if (err.code === 'ECONNREFUSED') {
+        tt.pass('cannot connect to the debugger');
+        tt.end();
+      } else {
+        tt.threw(err);
+      }
+    });
+    conn.once('connect', function() {
+      tt.fail('connect should fail now');
+      tt.end();
+      conn.end();
+    });
+  });
+
+  t.test('dbg-start master', function(tt) {
+    run.ctl(tt, 'dbg-start', 0, function(err, stdout, stderr) {
+      tt.match(stderr, /Cannot debug.*supervisor/);
+      tt.end();
+    });
+  });
+
+  t.test('dbg-stop master', function(tt) {
+    run.ctl(tt, 'dbg-stop', 0, function(err, stdout, stderr) {
+      tt.match(stderr, /Cannot debug.*supervisor/);
+      tt.end();
+    });
+  });
+
+  t.test('dbg-status master', function(tt) {
+    run.ctl(tt, 'dbg-status', 0, function(err, stdout, stderr) {
+      tt.match(stderr, /Cannot debug.*supervisor/);
+      tt.end();
+    });
+  });
+
+  t.test('exit', function(tt) {
+    run.ctl(tt, 'stop', [], function() {
+      tt.end();
+    });
+  });
+});
+
+// run supervisor
+function supervise(app, vars) {
+  var run = require.resolve('../bin/sl-run');
+  var ctl = path.join(app, '..', 'runctl');
+  var cleanLogArgs = [
+    '--no-timestamp-workers',
+    '--no-timestamp-supervisor',
+    '--no-log-decoration',
+  ];
+  var args = ['--control', ctl, '--cluster=1'].concat(cleanLogArgs);
+  try {
+    fs.unlinkSync(ctl);
+  } catch (er) {
+    console.log('no `%s` to cleanup: %s', ctl, er);
+  }
+
+  console.log('# supervise %s with %j', run, args);
+
+  var c = child.fork(run, args.concat([app]), {silent: true});
+
+  // don't let it live longer than us!
+  // XXX(sam) once sl-runctl et. al. self-exit on loss of parent, we
+  // won't need this, but until then...
+  process.on('exit', c.kill.bind(c));
+  function die() {
+    c.kill();
+    process.kill(process.pid, 'SIGTERM');
+  }
+  process.once('SIGTERM', die);
+  process.once('SIGINT', die);
+
+  c.ctl = runctl;
+  c.says = says;
+
+  return c;
+
+  function runctl(t, cmd, cmdArgs, callback) {
+    var runctljs = require.resolve('../bin/sl-runctl');
+    var args = [runctljs, '--control', ctl, cmd].concat(cmdArgs);
+    child.execFile(process.execPath, args, function(err, stdout, stderr) {
+      debug('# runctl %s %j: ', cmd, args, err, stdout, stderr);
+      if (callback) {
+        callback.apply(this, arguments);
+      }
+    });
+  }
+
+  function says(t, pat) {
+    var watcher = byline.createStream();
+    var found = false;
+    debug('# watching for: ', pat);
+    watcher.on('data', function(line) {
+      if (!found && pat.test(line)) {
+        found = true;
+        c.stdout.unpipe(watcher);
+      } else {
+        debug('# > %s', line);
+      }
+    });
+    watcher.on('unpipe', function() {
+      t.ok(found, 'saw '+ pat);
+      debug('# unpiped!');
+      t.end();
+    });
+    c.stdout.pipe(watcher);
+  }
+}


### PR DESCRIPTION
Implement control channel for strong-debugger:
 - a new command `dbg-start <worker>` to start the debugger
   on an arbitrary port assigned by the system
 - a new command `dbg-stop <worker>` to stop the debugger
 - a new command `dbg-status <worker` to query the debugger state

Add a new notification "debugger-status", it is reported by "dbg-start" and "dbg-stop" for consumption in strong-mesh-models.

See the [spike blog post](https://docs.google.com/document/d/1hPuuKQ3GCLKCUaQaNxuwyRqOfcI_tnqy5TLGLLdWHeM/edit) for a high-level architectural overview.

Connect to strongloop-internal/scrum-loopback#261
/to @kraman please review
/cc @sam-github 