### PR TITLE
runctl: only restart when tracing is changing

### DIFF
--- a/lib/runctl.js
+++ b/lib/runctl.js
@@ -235,10 +235,13 @@ function onRequest(req, callback) {
     rsp = requestAllTargets(req, callback);
 
   } else if (cmd === 'tracing') {
-    if (req.enabled) {
+    var enabled = !!process.env.STRONGLOOP_TRACING;
+    if (req.enabled && !enabled) {
       process.env.STRONGLOOP_TRACING = 1;
-    } else if (process.env.STRONGLOOP_TRACING !== null) {
+    } else if (!req.enabled && enabled) {
       delete process.env.STRONGLOOP_TRACING;
+    } else {
+      return;
     }
 
     try {


### PR DESCRIPTION
If trace state is set to the current trace state, don't restart all the
workers.

connected to strongloop-internal/scrum-nodeops#937