### PR TITLE
package: make binary debugger an optional dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "strong-agent": "^2.0.0",
     "strong-cluster-control": "^2.0.0",
     "strong-control-channel": "^2.0.0",
-    "strong-debugger": "^1.0.0",
     "strong-log-transformer": "^1.0.0",
     "strong-npm-ls": "^1.0.0",
     "strong-statsd": "^2.0.0",
@@ -72,6 +71,7 @@
   },
   "optionalDependencies": {
     "heapdump": "^0.3.5",
-    "modern-syslog": "^1.x"
+    "modern-syslog": "^1.x",
+    "strong-debugger": "^1.0.0"
   }
 }


### PR DESCRIPTION
Failure to build should not block strongloop installation.

Fix https://github.com/strongloop/strongloop/issues/255