### PR TITLE
fix regression in handling of symlinked PWD

### DIFF
--- a/lib/start-command.js
+++ b/lib/start-command.js
@@ -15,7 +15,9 @@ exports.fromStart = fromStart;
 // We want to be in the directory of the file we are running so we can pick up
 // configuration stored in it's working directory, so part of resolving the path
 // of the script is also resolving what directory the script should be run from.
-function resolveArgs(cwd, argv) {
+function resolveArgs(pwd, argv) {
+  var replacer = symlinkReplacer(pwd);
+  var cwd = realpath(pwd);
   var script = argv[2] || '.';
   debug('resolving CWD: %j, path: %j', cwd, script);
   var app = resolvePath(cwd, script);
@@ -29,7 +31,7 @@ function resolveArgs(cwd, argv) {
     // exist but which node would treat ass foo/app.js, so we'll just find the
     // the package's root directory and use that as the CWD when running the
     // specified script.
-    return resolvePackageFromPath(app.cwd, app.path);
+    return replacer(resolvePackageFromPath(app.cwd, app.path));
   }
 
   if (stat.isDirectory()) {
@@ -42,7 +44,7 @@ function resolveArgs(cwd, argv) {
     // 1. try parsing scripts.start from the package.json
     var pkgStart = resolvePackageStart(pkgApp.cwd);
     if (!pkgStart.error) {
-      return pkgStart;
+      return replacer(pkgStart);
     }
 
     // 2. try server.js, app.js, index.js**, then default module resolution
@@ -54,7 +56,7 @@ function resolveArgs(cwd, argv) {
                   ifExists(pkgApp.cwd, 'index.js') ||
                   requireable(pkgApp.cwd, pkgApp.path);
     if (pkgApp.path) {
-      return pkgApp;
+      return replacer(pkgApp);
     }
   }
 
@@ -162,4 +164,29 @@ function fromStart(cwd, script) {
     return {error: Error('Could not resolve start script ' + script)};
   }
   return {cwd: cwd, path: resolved};
+}
+
+function symlinkReplacer(link) {
+  var real = realpath(link);
+  if (real === link) {
+    return passThrough;
+  }
+  return replace;
+  function replace(app) {
+    if (app.cwd) {
+      app.cwd = app.cwd.replace(real, link);
+    }
+    return app;
+  }
+  function passThrough(app) {
+    return app;
+  }
+}
+
+function realpath(path) {
+  try {
+    return fs.readlinkSync(path);
+  } catch (e) {
+    return path;
+  }
 }

--- a/test/express-app-2/package.json
+++ b/test/express-app-2/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "express-app",
+  "description": "express-app",
+  "version": "0.0.0",
+  "main": "server/server.js"
+}

--- a/test/express-app-2/server/server.js
+++ b/test/express-app-2/server/server.js
@@ -1,0 +1,23 @@
+var options = require('optimist').argv;
+var express = require('express');
+var metrics = require('strong-express-metrics');
+
+var app = express();
+app.use(metrics());
+
+app.set('port', options.port || process.env.PORT || 0);
+
+app.get('/', (function(){
+  var started = new Date();
+  return function(req,res) {
+    res.send({
+      started: started,
+      uptime: (Date.now() - Number(started)) / 1000
+    });
+  }
+})());
+
+var server = app.listen(app.get('port'), function() {
+  console.log('express-app listening on http://localhost:%d',
+              server.address().port);
+});


### PR DESCRIPTION
Fix a regression that was introduced by #144 that changed how symlinks
were being handled. Unfortunately, this affects pretty much every use
since strong-pm is the primary dependant of strong-supervisor and it
uses symlinks for all deployments. The reason the problem wasn't more
obvious is because the code path that triggers this only really happens
when the app's main script is in a subdirectory of the package.

The root cause of this is that some of the methods of resolving the
start script make use of the builtin require.resolve(). Because
require() has to know the physical location of the module it loads so
that it knows how to resolve files relative to it, it has to resolve
symlinks and return the real path.

To account for this we can check if the pwd given to the start command
resolver is a symlink and if it is reverse the symlink resolution
before passing back the result.

This should resolve strongloop/strong-pm#283

Connect to strongloop/strong-pm#283