### PR TITLE
Rework debugger as an optional capability

### DIFF
--- a/lib/capabilities.js
+++ b/lib/capabilities.js
@@ -161,6 +161,21 @@ var capabilities = {
       }
     ]
   },
+  debugger: {
+    name: 'debugger',
+    checks: [
+      {
+        check: function(cb) {
+          var dbg = require('./debugger');
+          if (dbg) {
+            cb(true);
+          } else {
+            cb(false, 'Strong-debugger not compiled.');
+          }
+        }
+      }
+    ]
+  },
 };
 
 function listCapabilities() {

--- a/lib/debugger.js
+++ b/lib/debugger.js
@@ -1,0 +1,7 @@
+var debug = require('./debug')('debugger');
+try {
+  module.exports = require('strong-debugger');
+} catch (err) {
+  debug('Cannot load strong-debugger: ', err);
+  module.exports = null;
+}

--- a/lib/runctl.js
+++ b/lib/runctl.js
@@ -1,7 +1,6 @@
 // run-time control channel
 var agent = require('./agent');
 var agentVersion = require('strong-agent/package.json').version;
-var debuggerVersion = require('strong-debugger/package.json').version;
 var async = require('async');
 var cluster = require('cluster');
 var debug = require('./debug')('runctl');
@@ -14,6 +13,13 @@ var targetctl = require('./targetctl');
 var util = require('util');
 var wsChannel = require('strong-control-channel/ws-channel').connect;
 var processChannel = require('strong-control-channel/process').attach;
+
+var debuggerVersion = 'n/a';
+try {
+  debuggerVersion = require('strong-debugger/package.json').version;
+} catch (err) {
+  debug('Cannot load strong-debugger: ', err);
+}
 
 exports.start = start;
 exports.onRequest = onRequest; // For testing

--- a/lib/targetctl.js
+++ b/lib/targetctl.js
@@ -8,7 +8,7 @@ var fs = require('fs');
 var capabilities = require('./capabilities');
 var heapdump = null;
 var async = require('async');
-var strongDebugger = require('strong-debugger');
+var strongDebugger = require('./debugger');
 var extend = require('util')._extend;
 
 // override any other options since some of them will break us
@@ -227,6 +227,11 @@ function startDebugger(req, rsp, callback) {
     return callback(rsp);
   }
 
+  if (!strongDebugger) {
+    rsp.error = 'Cannot load the debugger module.';
+    return callback(rsp);
+  }
+
   strongDebugger.start(0, function(err, port) {
     rsp.error = err && err.message;
     rsp.port = port;
@@ -238,6 +243,11 @@ function startDebugger(req, rsp, callback) {
 function stopDebugger(req, rsp, callback) {
   if (cluster.isMaster) {
     rsp.error = 'Cannot debug the supervisor process itself.';
+    return callback(rsp);
+  }
+
+  if (!strongDebugger) {
+    rsp.error = 'Cannot load the debugger module.';
     return callback(rsp);
   }
 
@@ -260,6 +270,11 @@ function addDebuggerStatusNotification(rsp) {
 function debuggerStatus(req, rsp, callback) {
   if (cluster.isMaster) {
     rsp.error = 'Cannot debug the supervisor process itself.';
+    return callback(rsp);
+  }
+
+  if (!strongDebugger) {
+    rsp.error = 'Cannot load the debugger module.';
     return callback(rsp);
   }
 

--- a/test/test-capablities.js
+++ b/test/test-capablities.js
@@ -3,7 +3,7 @@ var tap = require('tap');
 
 tap.test('targetctl capabilities', function(t) {
   var caps = ['watchdog', 'tracing', 'metrics',
-      'cpuprofile', 'heapsnapshot', 'patch'];
+      'cpuprofile', 'heapsnapshot', 'patch', 'debugger'];
   var list = capabilities.list();
   t.match(list, caps, 'Capabilities are defined.');
   list.forEach(function(f) {


### PR DESCRIPTION
 - Add "lib/debugger" wrapper which returns "null" when the module cannot be loaded.
 - Rework "lib/runctl" to check if the debugger addon is available and return a descriptive error otherwise.
 - Add a capability check to "lib/capabilities".

Connect to strongloop-internal/scrum-loopback#504

/to @sam-github please review
/cc @kraman 

The patch is much simpler & shorter than I anticipated. Did I miss anything (possibly in other projects, like strong-mesh-models)? Is this all what's needed to correctly support the use case where strong-debugger is not installed?