### PR TITLE
Fix incorrect handling of relative symlinks

### DIFF
--- a/lib/start-command.js
+++ b/lib/start-command.js
@@ -17,7 +17,7 @@ exports.fromStart = fromStart;
 // of the script is also resolving what directory the script should be run from.
 function resolveArgs(pwd, argv) {
   var replacer = symlinkReplacer(pwd);
-  var cwd = realpath(pwd);
+  var cwd = fs.realpathSync(pwd);
   var script = argv[2] || '.';
   debug('resolving CWD: %j, path: %j', cwd, script);
   var app = resolvePath(cwd, script);
@@ -167,7 +167,7 @@ function fromStart(cwd, script) {
 }
 
 function symlinkReplacer(link) {
-  var real = realpath(link);
+  var real = fs.realpathSync(link);
   if (real === link) {
     return passThrough;
   }
@@ -180,13 +180,5 @@ function symlinkReplacer(link) {
   }
   function passThrough(app) {
     return app;
-  }
-}
-
-function realpath(path) {
-  try {
-    return fs.readlinkSync(path);
-  } catch (e) {
-    return path;
   }
 }

--- a/test/test-package-start-parsing.js
+++ b/test/test-package-start-parsing.js
@@ -45,15 +45,23 @@ tap.test('resolve wrapper', function(t) {
   t.end();
 });
 
-tap.test('symlinks', function(t) {
+tap.test('symlinks - simple', function(t) {
   var expresslink = symlink(expressApp);
   t.match(startCmd(expresslink, slRun()),
           {cwd: expresslink, path: 'server.js'},
           'maintains simple symlink paths');
-  var express2link = symlink(expressApp2);
+  t.end();
+});
+
+tap.test('symlinks - relative', function(t) {
+  var express2link = symlink('test/express-app-2');
   t.match(startCmd(express2link, slRun()),
           {cwd: express2link, path: 'server/server.js'},
           'maintains deeper symlink main path');
+  t.end();
+});
+
+tap.test('symlinks - deep', function(t) {
   var modLink = symlink(moduleApp);
   t.match(startCmd(modLink, slRun('path/to/deep.js')),
           {cwd: modLink, path: 'path/to/deep.js'},
@@ -191,13 +199,16 @@ function slRun() {
   return [process.execPath, 'sl-run'].concat(args);
 }
 
-function symlink(from) {
+function symlink(fromPath) {
+  if (/^test\//.test(fromPath)) {
+    fromPath = path.relative('test', fromPath);
+  }
   // Delete last symlink, if it exists
   try {
     fs.unlinkSync('test/sx-app');
   } catch (er) {
     // ignore
   }
-  fs.symlinkSync(from, 'test/sx-app');
+  fs.symlinkSync(fromPath, 'test/sx-app');
   return 'test/sx-app';
 }


### PR DESCRIPTION
A regression was introduced by #165 that only appeared when strong-pm
used relative paths, which was the case in strong-pm@5.0.0, but not in
strong-pm@5.0.1.

@sam-github @piscisaureus PTAL.