### PR TITLE
lint: fix style warnings in lib/logger.js

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -13,14 +13,14 @@ Logger.prototype.log = Logger.prototype.info;
 Logger.prototype.warn = partial(LevelLog, 'WARN');
 Logger.prototype.error = partial(LevelLog, 'ERROR');
 
-function LevelLog(level /*, items... */) {
+function LevelLog(level/*, items... */) {
   var items = [].slice.call(arguments, 1);
   this.sink.write(level + ' ' +
                   util.format.apply(util, items) +
                   '\n');
 }
 
-function partial(fn /*, firstArgs... */) {
+function partial(fn/*, firstArgs... */) {
   var firstArgs = [].slice.call(arguments, 1);
   return function() {
     var args = firstArgs.concat([].slice.call(arguments));


### PR DESCRIPTION
Fixes the following warnings:

    16:41  error  There should be no spaces inside this paren
    23:41  error  There should be no spaces inside this paren

R=@sam-github