### PR TITLE
Emit CPU and memory usage from appmetrics

### DIFF
--- a/disable-mqtt.js
+++ b/disable-mqtt.js
@@ -1,0 +1,14 @@
+var fs = require('fs');
+// NOTE(bajtos) By default, appmetrics is configured to connect to a local
+// MQTT broker. The only reliable way how to disable this behaviour is to edit
+// appmetrics.properties in module's installation directory.
+try {
+  var propFile = require.resolve('appmetrics/appmetrics.properties');
+  var content = fs.readFileSync(propFile, 'utf-8');
+  content = content.replace(
+    /com.ibm.diagnostics.healthcenter.mqtt\s*=\s*on/,
+    'com.ibm.diagnostics.healthcenter.mqtt=off');
+  fs.writeFileSync(propFile, content);
+} catch (err) {
+  console.warn('Cannot modify appmetrics.properties:', err.message);
+}

--- a/lib/watcher/appmetrics.js
+++ b/lib/watcher/appmetrics.js
@@ -1,0 +1,60 @@
+var UNUSED_PROBES = [
+  'eventloop',
+  'profiling',
+  'http',
+  'mongo',
+  'socketio',
+  'mqlight',
+  'postgresql',
+  'mqtt',
+  'mysql',
+  'redis',
+  'memcached',
+  'oracledb',
+  'strong-oracle',
+  'requests',
+  'trace',
+];
+
+exports.worker = function(handle) {
+  var appmetrics = require('appmetrics');
+
+  UNUSED_PROBES.forEach(function(p) {
+    appmetrics.disable(p);
+  });
+
+  var monitoring = appmetrics.monitor();
+
+  monitoring.on('initialized', function(/* env */) {
+    handle.debug('appmetrics initialized');
+  });
+
+  monitoring.on('cpu', function(data) {
+    handle.debug('appmetrics event - cpu: %j', data);
+    handle.send({
+      cmd: 'appmetrics:cpu',
+      data: data
+    });
+  });
+
+  monitoring.on('memory', function(data) {
+    handle.debug('appmetrics event - memory: %j', data);
+    handle.send({
+      cmd: 'appmetrics:memory',
+      data: data
+    });
+  });
+};
+
+exports.master = function(handle) {
+  handle.on('appmetrics:cpu', addMasterData);
+  handle.on('appmetrics:memory', addMasterData);
+
+  function addMasterData(msg, worker) {
+    // Mix-in the worker identity: startTime is known only in the master, and
+    // worker.id is just convenient to do here.
+    msg.pst = worker.startTime;
+    msg.wid = worker.id;
+    handle.send(msg);
+  }
+};

--- a/package.json
+++ b/package.json
@@ -35,9 +35,10 @@
   "scripts": {
     "lint": "eslint ./",
     "pretest": "npm run lint",
-    "test": "tap --bail --timeout 300 test/test-watch-heart-beat.js"
+    "test": "tap --bail --timeout 300 test/test-watch-heart-beat.js test/test-run-appmetrics-usage.js"
   },
   "dependencies": {
+    "appmetrics": "^1.0.6",
     "async": "^1.0.0",
     "debug": "^2.0.0",
     "dotenv": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "slrc": "./bin/sl-runctl.js"
   },
   "scripts": {
+    "postinstall": "node disable-mqtt.js",
     "lint": "eslint ./",
     "pretest": "npm run lint",
     "test": "tap --bail --timeout 300 test/test-watch-heart-beat.js test/test-run-appmetrics-usage.js"

--- a/test/helper.js
+++ b/test/helper.js
@@ -167,6 +167,7 @@ exports.runWithControlChannel = function(appWithArgs, runArgs, onMessage) {
 
   var args = [
     runner,
+    '--no-profile',
     '--no-timestamp-workers',
     '--no-timestamp-supervisor'
   ].concat(runArgs).concat(appWithArgs);

--- a/test/helper.js
+++ b/test/helper.js
@@ -156,7 +156,7 @@ exports.runWithControlChannel = function(appWithArgs, runArgs, onMessage) {
   }
 
   var options = {
-    stdio: [0, 1, 2, 'ipc'],
+    stdio: [0, 2, 2, 'ipc'],
     env: util._extend({
       STRONGLOOP_BASE_INTERVAL: 500,
       STRONGLOOP_FLUSH_INTERVAL: 2,

--- a/test/test-run-appmetrics-usage.js
+++ b/test/test-run-appmetrics-usage.js
@@ -1,0 +1,45 @@
+var debug = require('./debug');
+var helper = require('./helper');
+var run = helper.runWithControlChannel;
+var tap = require('tap');
+
+tap.test('appmetrics are forwarded via parentCtl', function(t) {
+  var expressApp = require.resolve('./express-app');
+  var received = {};
+  var app = run([expressApp], ['--cluster=1', '--no-control'], function(msg) {
+    debug('received: cmd %s: %j', msg.cmd, msg);
+    switch (msg.cmd) {
+      case 'appmetrics:cpu':
+        t.deepEqual(Object.keys(msg.data), [
+          'time',
+          'process',
+          'system',
+        ]);
+        received.cpu = true;
+        break;
+
+      case 'appmetrics:memory':
+        t.deepEqual(Object.keys(msg.data), [
+          'time',
+          'physical_total',
+          'physical_used',
+          'physical',
+          'private',
+          'virtual',
+          'physical_free',
+        ]);
+        received.memory = true;
+        break;
+    }
+
+    if (received.cpu && received.memory)
+      app.kill();
+  });
+
+  // keep test alive until app exits
+  app.ref();
+  app.on('exit', function(code, signal) {
+    debug('supervisor exit: %s', signal || code);
+    t.end();
+  });
+});


### PR DESCRIPTION
Add a new watcher called "appmetrics" that emits the following two events via the IPC channel:

```
1) cmd: "appmetrics:cpu"
   data: an object with the following properties:
    - time (Number) the milliseconds when the sample was taken.
      This can be converted to a Date using new Date(data.time).
    - process (Number) the percentage of CPU used by the application
      itself. This is a value between 0.0 and 1.0.
    - system (Number) the percentage of CPU used by the system as a whole.
      This is a value between 0.0 and 1.0.

2) cmd: "appmetrics:memory"
   data: an object with the following properties:
    - time (Number) the milliseconds when the sample was taken.
      This can be converted to a Date using new Date(data.time).
    - physical_total (Number) the total amount of RAM available
      on the system in bytes.
    - physical_used (Number) the total amount of RAM in use
      on the system in bytes.
    - physical_free (Number) the total amount of free RAM available
      on the system in bytes.
    - virtual (Number) the memory address space used by the application
      in bytes.
    - private (Number) the amount of memory used by the application
      that cannot be shared with other processes, in bytes.
    - physical (Number) the amount of RAM used by the application in bytes.
```

Connect to strongloop-internal/scrum-nodeops#1057

@sam-github please review