### PR TITLE
Fix discrepancies between sl-run.txt and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,10 +178,19 @@ Run an app, allowing it to be profiled (using StrongOps) and supervised.
 `app` can be a node file to run or a package directory. The default value is
 ".", the current working directory. Packages will be run by requiring the first
 that is found of:
-  1. server.js
-  2. app.js
-  3. `main` property of package.json
-  4. index.js
+  1. JS file mentioned in `scripts.start` of package.json
+    *** NOTE: the script is no run and arguments are not preserved, only the
+        path of the script is used, eg:
+          `node --nodearg script.js --scriptarg` => 'script.js'
+          `node bin/www` => `bin/www`
+        The parser is simple, so options that accept arguments `--flag value`
+        will cause problems.
+  2. server.js
+  3. app.js
+  4. result of require(app)
+    1. `main` property of app package.json
+    2. `app`.js
+    3. `app`/index.js
 
 Options:
   -h,--help          Print this message and exit.


### PR DESCRIPTION
I believe the `README.md` was not updated to reflect the changes between 2.0.2 and 3.0.1. Let me know if I am mistaken.

See the diff here: https://github.com/strongloop/strong-supervisor/compare/v2.0.2...v3.0.1#diff-46f479b5c04f3006931226f71d34d83eR8