### PR TITLE
options: preserve url protocol

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -10,7 +10,6 @@
 // order up to the first non-option (as getopt_long could do), and failing. I'll
 // keep looking, but in the meantime, this works fine.
 var ExitError = require('./errors').ExitError;
-var debug = require('./debug')('options');
 var defaults = require('strong-url-defaults');
 var fmt = require('util').format;
 var fs = require('fs');
@@ -174,21 +173,26 @@ exports.parse = function parse(argv) {
   } else {
     throw new ExitError(fmt('Invalid cluster option: %s', cluster));
   }
-  debug(options.channel);
   var protocol;
+  // The protocol includes the colon on parsing!
+  var protocolMap = {
+    'http:': 'http',
+    'https:': 'http',
+    'ws:': 'ws',
+    'wss:': 'wss',
+    // Default will be 'ws'
+  };
   if (options.channel && (protocol = url.parse(options.channel).protocol)) {
     options.channel = defaults(options.channel, {
       path: 'supervisor-control'
     }, {
-      protocol: protocol === 'wss' ? 'wss' : protocol
+      protocol: protocolMap[protocol] || 'ws',
     });
-    debug('channel: ' + options.channel);
     process.env.STRONGLOOP_CONTROL = options.channel;
     options.channel = false;
   } else {
     delete process.env.STRONGLOOP_CONTROL;
   }
-
   return options;
 };
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -10,6 +10,7 @@
 // order up to the first non-option (as getopt_long could do), and failing. I'll
 // keep looking, but in the meantime, this works fine.
 var ExitError = require('./errors').ExitError;
+var debug = require('./debug')('options');
 var defaults = require('strong-url-defaults');
 var fmt = require('util').format;
 var fs = require('fs');
@@ -173,13 +174,15 @@ exports.parse = function parse(argv) {
   } else {
     throw new ExitError(fmt('Invalid cluster option: %s', cluster));
   }
-
-  if (options.channel && url.parse(options.channel).protocol) {
+  debug(options.channel);
+  var protocol;
+  if (options.channel && (protocol = url.parse(options.channel).protocol)) {
     options.channel = defaults(options.channel, {
       path: 'supervisor-control'
     }, {
-      protocol: 'ws'
+      protocol: protocol === 'wss' ? 'wss' : protocol
     });
+    debug('channel: ' + options.channel);
     process.env.STRONGLOOP_CONTROL = options.channel;
     options.channel = false;
   } else {


### PR DESCRIPTION
connected to https://github.com/strongloop-internal/scrum-nodeops/issues/1723

Application of defaults to channel now uses the protocol originally
parsed from the URL.