### PR TITLE
adapter: remove reference to old express data

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -376,12 +376,6 @@ function createMessageListener() {
 
 function createProbeListener(probeName) {
   monitor.on(probeName, function(res) {
-    var duration = 0;
-    if (probeName === 'express' && res.response) {
-      duration = res.response.duration;
-    } else {
-      duration = res.duration;
-    }
     // If no metrics object exists, create one
     if (!probeMetrics[probeName]) {
       probeMetrics[probeName] = {
@@ -391,7 +385,7 @@ function createProbeListener(probeName) {
     }
 
     // Update all metrics accordingly
-    updateMetrics(probeName, duration);
+    updateMetrics(probeName, res.duration);
   });
 }
 


### PR DESCRIPTION
The res.response.duration refers to an earlier version of the appmetrics
express probe, removed in
https://github.com/RuntimeTools/appmetrics/pull/260, and replaced with
https://github.com/RuntimeTools/appmetrics/blob/master/probes/express-probe.js,
which uses the common duration property, and no longer needs special
casing.