### PR TITLE
dashboard: fix log msg when dashboard is enabled

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -20,7 +20,6 @@ exports = module.exports = function dashboard(uri, appmetrics, dashboard) {
 
   // appmetrics-dash calls the path 'url' XXX(sam) maybe it should not?
   options.url = options.path;
-  delete options.path;
 
   options.docs = process.env.STRONGLOOP_DASHBOARD_DOCS;
   options.title = process.env.STRONGLOOP_DASHBOARD_TITLE;


### PR DESCRIPTION
Fix regression in log message,
https://github.com/strongloop/strong-supervisor/blob/5440dfdb1bb3d756a142e940b77d2c5f1f7c5a5e/lib/adapter.js#L225
still requires options.path to exist.