### PR TITLE
package: use appmetrics 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test": "tap --timeout 300 test/test-*.js"
   },
   "dependencies": {
-    "appmetrics": "^1.1.0",
+    "appmetrics": "^2.0.1",
     "appmetrics-dash": "^3.0.0",
     "async": "^2.0.0",
     "debug": "^2.0.0",


### PR DESCRIPTION
see https://github.com/RuntimeTools/appmetrics-dash/issues/26#issuecomment-285614956

Breaking change from 1.x --> 2.x was dropping of support for node versions which supervisor doesn't need support for either, they aren't LTS.

/to @tobespc @rmg 