### PR TITLE
package: use appmetrics 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test": "tap --timeout 300 test/test-*.js"
   },
   "dependencies": {
-    "appmetrics": "^2.0.1",
+    "appmetrics": "^3.x",
     "appmetrics-dash": "^3.0.0",
     "async": "^2.0.0",
     "debug": "^2.0.0",


### PR DESCRIPTION
3.x removed an express probe that was unused by supervisor, and is
otherwise backwards compatible.