### PR TITLE
travis: replace Node 7 with 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "4"
   - "6"
-  - "7"
+  - "8"
 env:
   - CXX=g++-4.8
 addons:


### PR DESCRIPTION
Update Travis config to use Node 8 instead of 7.